### PR TITLE
Add first secret using dotenv

### DIFF
--- a/gw_spaceheat/README.md
+++ b/gw_spaceheat/README.md
@@ -1,4 +1,4 @@
-**Step 1: Set up python environment for development**
+## Step 1: Set up python environment for development
  - Use python 3.8.6
 - .gitignore includes gw_platform_django/venv for virtualenv so from gw_platform_django directory:
   - `python -m venv venv`  
@@ -6,7 +6,7 @@
   - `pip install -r requirements/dev.txt` 
 
 
-      
+### Adding libraries 
 - If you are going to add libraries, install pip-tools to your venv:
   - `python -m pip install pip-tools`
   - If you want to add a new library used in all contexts, then add it to requirements/base.in and run
@@ -16,3 +16,15 @@
 We use pip-tools to organize requirements. The `.in` files clarify the key modules (including which ones are important to pin and which ones can be set to the latest release) and then the corresponding `.txt` files are generated via pip-tools. This means we always run on pinned requirements (from the .txt files) and can typically upgrade to the latest release, except for cases where the code requires a pinned older version.
 
 The pip-tools also allow for building layers of requirements on top of each other. This allows us to have development tools that are not needed in production to show up for the first time in `dev.txt`, for example (like the pip-tool itself).
+
+## Handling secrets and config variables
+
+Secrets use dotenv module in a gitignored gw-scada-spaceheat-python/.env file, through the helpers.get_secret function. Ask somebody on the team for the secrets.
+
+Convention: if you have a secret key,value pair where the value is None then add it to the .env file like this:
+
+MQTT_PW = None
+
+and the helper function will turn that None into the python None.
+
+Settings use a gitignored settings.py file. There is a template settings_template.py.

--- a/gw_spaceheat/actors/actor_base.py
+++ b/gw_spaceheat/actors/actor_base.py
@@ -1,11 +1,11 @@
-import os
 from abc import ABC, abstractmethod
 import paho.mqtt.client as mqtt
 import threading
 from typing import List
 from data_classes.sh_node import ShNode
-from actors.mqtt_utils import Subscription, QOS
+from actors.mqtt_utils import Subscription
 import settings
+import helpers
 
 class ActorBase(ABC):
 
@@ -13,10 +13,10 @@ class ActorBase(ABC):
         self.node = node
         self.mqttBroker = settings.MQTT_BROKER_ADDRESS
         self.publish_client = mqtt.Client(f"{node.alias}-pub")
-        self.publish_client.username_pw_set(username=settings.MQTT_USER_NAME, password=None)
+        self.publish_client.username_pw_set(username=settings.MQTT_USER_NAME, password=helpers.get_secret('MQTT_PW'))
         self.publish_client.connect(self.mqttBroker)
         self.consume_client = mqtt.Client(f"{node.alias}")
-        self.consume_client.username_pw_set(username=settings.MQTT_USER_NAME, password=None)
+        self.consume_client.username_pw_set(username=settings.MQTT_USER_NAME, password=helpers.get_secret('MQTT_PW'))
         self.consume_client.connect(self.mqttBroker)
         self.consume_thread = threading.Thread(target=self.consume)
 

--- a/gw_spaceheat/helpers.py
+++ b/gw_spaceheat/helpers.py
@@ -13,4 +13,6 @@ def get_secret(key):
     value = os.getenv(key)
     if  value is None:
         raise Exception(f"Missing {key} value in gw-scada-spaceheat-python/.env file!")
+    elif value == 'None':
+        return None
     return value


### PR DESCRIPTION
Sometimes (like with this dev MQTT example) the value of the secret is in fact None and we want it to be None (i.e., no password)

The dotenv os.getenv(key) returns 'None' when .env file has MQTT_PW = None.

I've changed the helper so that a None setting in .env is treated as python None.