### PR TITLE
Boolean actuation works in test bed for boost and pump

### DIFF
--- a/gw_spaceheat/README.md
+++ b/gw_spaceheat/README.md
@@ -19,6 +19,7 @@ The pip-tools also allow for building layers of requirements on top of each othe
 
 ### Handling secrets and config variables
 
+SETTING UP SECRETS.
 Secrets use dotenv module in a gitignored gw-scada-spaceheat-python/.env file, through the helpers.get_secret function. Ask somebody on the team for the secrets.
 
 Convention: if you have a secret key,value pair where the value is None then add it to the .env file like this:
@@ -26,6 +27,8 @@ Convention: if you have a secret key,value pair where the value is None then add
 MQTT_PW = None
 
 and the helper function will turn that None into the python None.
+
+SETTING UP NON_SECRET CONFIGS. Copy gw-scada-spaceheat-python/gw_spaceheat/settings_template.py  to [same]/settings.py
 
 Settings use a gitignored settings.py file. There is a template settings_template.py.
 

--- a/gw_spaceheat/actors/primary_scada/primary_scada.py
+++ b/gw_spaceheat/actors/primary_scada/primary_scada.py
@@ -66,5 +66,5 @@ class PrimaryScada(PrimaryScadaBase):
     def turn_on(self, ba: BooleanActuator):
         ba.turn_on()
 
-    def turn_relay_off(self, ba: BooleanActuator):
+    def turn_off(self, ba: BooleanActuator):
         ba.turn_off()

--- a/gw_spaceheat/data_classes/boolean_actuator_component.py
+++ b/gw_spaceheat/data_classes/boolean_actuator_component.py
@@ -33,7 +33,7 @@ class BooleanActuatorComponent(Component):
         self.gpio= gpio
 
     def __repr__(self):
-        return f'Component {self.display_name} => Cac {self.cac.display_name}'
+        return f'Component {self.display_name} => Cac {self.cac.display_name}. GPIO: {self.gpio}'
 
     @classmethod
     def check_uniqueness_of_primary_key(cls, attributes):

--- a/gw_spaceheat/data_classes/sh_node_role_static.py
+++ b/gw_spaceheat/data_classes/sh_node_role_static.py
@@ -18,13 +18,13 @@ DEDICATED_THERMAL_STORE = ShNodeRole(alias="DedicatedThermalStore",
 
 PlatformShNodeRole[DEDICATED_THERMAL_STORE.alias] = DEDICATED_THERMAL_STORE
 
-HEAT_DISTRIBUTION_PUMP = ShNodeRole(alias="HeatDistributionPump",
+CIRCULATOR_PUMP = ShNodeRole(alias="CirculatorPump",
         has_heat_flow=False,
         has_voltage=False,
         has_stored_thermal_energy=False,
         is_actuated=True)
 
-PlatformShNodeRole[HEAT_DISTRIBUTION_PUMP.alias] = HEAT_DISTRIBUTION_PUMP
+PlatformShNodeRole[CIRCULATOR_PUMP.alias] = CIRCULATOR_PUMP
 
 PASSIVE_ROOM_HEATER = ShNodeRole(alias="PassiveRoomHeater",
         has_heat_flow=True,

--- a/gw_spaceheat/docs/learning/pi_setup.md
+++ b/gw_spaceheat/docs/learning/pi_setup.md
@@ -42,6 +42,7 @@ sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev
 regular pip was going to /usr/bin/pip and failing. Did this:
  /usr/local/bin/pip3.8 install -r requirements/drivers.txt
 
+This installed dotenv in the wrong place though ...
 
 # Raspberry Pi i2c 
 

--- a/gw_spaceheat/docs/learning/pi_setup.md
+++ b/gw_spaceheat/docs/learning/pi_setup.md
@@ -60,3 +60,16 @@ After loading the various drivers, I tried to run the simple-gpio-monitor script
 navigating to Interfacing Options, selecting i2c, and enabling it. Alternatively,
 sudo nano /boot/config.txt and make sure it has the a line with dtparam=i2c_arm=on
 
+# MQTT
+
+installing MQTT command-line tool:
+sudo apt-get update
+sudo apt-get install mosquitto-clients
+sudo apt clean
+
+testing broker access (needs to be on the same LAN as moquitto broker)
+mosquitto_sub -v -u MQTT_USERNAME -P MQTT_PW -t 'test'
+mosquitto_pub -u MQTT_USERNAME -P MQTT_PW -t 'test' -m 'hi'
+
+(see settings.py for username and .env for password)
+

--- a/gw_spaceheat/drivers/boolean_actuator/ncd__pr8_14_spst__boolean_actuator.py
+++ b/gw_spaceheat/drivers/boolean_actuator/ncd__pr8_14_spst__boolean_actuator.py
@@ -24,4 +24,8 @@ class Ncd__Pr8_14_Spst__BooleanActuator(BooleanActuator):
     def turn_off(self):
         self.mcp23008_driver.turn_off_relay(self.component.gpio)
 
+    def is_on(self):
+        return self.mcp23008_driver.get_single_gpio_status(self.component.gpio)
+    
+
 

--- a/gw_spaceheat/input_data/dev_house.json
+++ b/gw_spaceheat/input_data/dev_house.json
@@ -68,8 +68,8 @@
         },
         {
             "Alias": "a.tank.out.pump",
-            "ShNodeRoleAlias": "HeatDistributionPump",
-            "DisplayName": "Heat Distribution Pump",
+            "ShNodeRoleAlias": "CirculatorPump",
+            "DisplayName": "Circulator Pump",
             "ShNodeId": "f3db8728-1751-4f30-a739-d56bbff9971e",
             "PrimaryComponentId": "1c207b38-d7bf-41cd-a9ad-6204bbab9922"
         },
@@ -270,7 +270,7 @@
         },
         {
             "ComponentId": "1c207b38-d7bf-41cd-a9ad-6204bbab9922",
-            "DisplayName": "Heat Distribution Pump",
+            "DisplayName": "Circulator Pump",
             "ComponentAttributeClassId": "f9a35cca-2b6d-418d-a81f-81f1c3d64776"
         },
         {

--- a/gw_spaceheat/input_data/dev_house.json
+++ b/gw_spaceheat/input_data/dev_house.json
@@ -74,6 +74,13 @@
             "PrimaryComponentId": "1c207b38-d7bf-41cd-a9ad-6204bbab9922"
         },
         {
+            "Alias": "a.tank.out.pump.relay",
+            "ShNodeRoleAlias": "Actuator",
+            "DisplayName": "Circulator Pump Boolean Actuator",
+            "ShNodeId": "357a45f0-1a57-4f3d-9be4-4ff77cf19ba2",
+            "PrimaryComponentId": "e758eecd-6439-4e1d-9f66-534f6fc14859"
+        },
+        {
             "Alias": "a.tank.out.pump.allradiators",
             "ShNodeRoleAlias": "PassiveRoomHeater",
             "DisplayName": "All the garage passive radiators",
@@ -192,9 +199,10 @@
             "Gpio": 0
         },
         {
-            "ComponentId": "a128bda4-3674-4d55-b2b4-61a39d5cf886",
-            "DisplayName": "Little Orange House Primary Scada",
-            "ComponentAttributeClassId": "2d83cf4a-cb4f-46e6-a0ce-a13659694c90"
+            "ComponentId": "e758eecd-6439-4e1d-9f66-534f6fc14859",
+            "DisplayName": "relay for main circulator pump",
+            "ComponentAttributeClassId": "69f101fc-22e4-4caa-8103-50b8aeb66028",
+            "Gpio": 0
         }
     ],
     "SensorComponents": [
@@ -240,6 +248,11 @@
         }
     ],
     "OtherComponents": [
+        {
+            "ComponentId": "a128bda4-3674-4d55-b2b4-61a39d5cf886",
+            "DisplayName": "Little Orange House Primary Scada",
+            "ComponentAttributeClassId": "2d83cf4a-cb4f-46e6-a0ce-a13659694c90"
+        },
         {
             "ComponentId": "d4a27899-98a3-409f-8c6a-771d86d7937b",
             "DisplayName": "Little Orange house Axeman Tank",

--- a/gw_spaceheat/input_data/pi_dev_house.json
+++ b/gw_spaceheat/input_data/pi_dev_house.json
@@ -196,13 +196,13 @@
             "ComponentId": "57e2eb41-08f4-4032-8948-b14890fce9ca",
             "DisplayName": "relay for first elt in tank",
             "ComponentAttributeClassId": "c6e736d8-8078-44f5-98bb-d72ca91dc773",
-            "Gpio": 0
+            "Gpio": 2
         },
         {
             "ComponentId": "7de91fae-72ab-4226-8ebe-f66a9d85cea4",
             "DisplayName": "relay for main circulator pump",
             "ComponentAttributeClassId": "c6e736d8-8078-44f5-98bb-d72ca91dc773",
-            "Gpio": 1
+            "Gpio": 3
         }
     ],
     "SensorComponents": [

--- a/gw_spaceheat/input_data/pi_dev_house.json
+++ b/gw_spaceheat/input_data/pi_dev_house.json
@@ -68,7 +68,7 @@
         },
         {
             "Alias": "a.tank.out.pump",
-            "ShNodeRoleAlias": "HeatDistributionPump",
+            "ShNodeRoleAlias": "CirculatorPump",
             "DisplayName": "Circulator Pump",
             "ShNodeId": "f3db8728-1751-4f30-a739-d56bbff9971e",
             "PrimaryComponentId": "1c207b38-d7bf-41cd-a9ad-6204bbab9922"
@@ -270,7 +270,7 @@
         },
         {
             "ComponentId": "1c207b38-d7bf-41cd-a9ad-6204bbab9922",
-            "DisplayName": "Heat Distribution Pump",
+            "DisplayName": "Circulator Pump",
             "ComponentAttributeClassId": "f9a35cca-2b6d-418d-a81f-81f1c3d64776"
         },
         {

--- a/gw_spaceheat/input_data/pi_dev_house.json
+++ b/gw_spaceheat/input_data/pi_dev_house.json
@@ -69,9 +69,16 @@
         {
             "Alias": "a.tank.out.pump",
             "ShNodeRoleAlias": "HeatDistributionPump",
-            "DisplayName": "Heat Distribution Pump",
+            "DisplayName": "Circulator Pump",
             "ShNodeId": "f3db8728-1751-4f30-a739-d56bbff9971e",
             "PrimaryComponentId": "1c207b38-d7bf-41cd-a9ad-6204bbab9922"
+        },
+        {
+            "Alias": "a.tank.out.pump.relay",
+            "ShNodeRoleAlias": "Actuator",
+            "DisplayName": "Circulator Pump Boolean Actuator",
+            "ShNodeId": "357a45f0-1a57-4f3d-9be4-4ff77cf19ba2",
+            "PrimaryComponentId": "7de91fae-72ab-4226-8ebe-f66a9d85cea4"
         },
         {
             "Alias": "a.tank.out.pump.allradiators",
@@ -192,9 +199,10 @@
             "Gpio": 0
         },
         {
-            "ComponentId": "a128bda4-3674-4d55-b2b4-61a39d5cf886",
-            "DisplayName": "Little Orange House Primary Scada",
-            "ComponentAttributeClassId": "2d83cf4a-cb4f-46e6-a0ce-a13659694c90"
+            "ComponentId": "7de91fae-72ab-4226-8ebe-f66a9d85cea4",
+            "DisplayName": "relay for main circulator pump",
+            "ComponentAttributeClassId": "c6e736d8-8078-44f5-98bb-d72ca91dc773",
+            "Gpio": 1
         }
     ],
     "SensorComponents": [
@@ -240,6 +248,11 @@
         }
     ],
     "OtherComponents": [
+        {
+            "ComponentId": "a128bda4-3674-4d55-b2b4-61a39d5cf886",
+            "DisplayName": "Little Orange House Primary Scada",
+            "ComponentAttributeClassId": "2d83cf4a-cb4f-46e6-a0ce-a13659694c90"
+        },
         {
             "ComponentId": "d4a27899-98a3-409f-8c6a-771d86d7937b",
             "DisplayName": "Little Orange house Axeman Tank",


### PR DESCRIPTION
This code change happened as George and I set up the test heating system in the garage. The system now has a working boost element and circulator pump, and the tank is full of water that circulates through the one radiator. We successfully heated up the water so that the temperature change was noticeable when touching the tank or pumps (from cold to lukewarm) and also ran the pump.

Changes happened a bit on the fly. Things that I noticed:
   1) We can change the gpio pin of the component dataclass object. Doing this should generate an MQTT message that gets logged by the authority for this part of the component configuration data. 
   2) Some of the component dataclass properties belong to the GNodeRegistry (properties related to max rated power, for example) and some do not. Have not yet figured out where the non GNodeRegistry authority should be. Perhaps local on the SCADA?
  3) the boolean actuator drivers can typically detect if their relay is open or closed. This can/should be the first of a series of sensing tests in the control logic. If we implement this, it will be likely that we will want an actor for the boolean actuator that is constantly sensing this. In this case, modularity suggests that turn_on and turn_off will become MQTT messages from the primary scada actor to the boolean actuator actor, instead of function calls. This is stubbed out in for example line 68 of the primary_scada code: if the boolean actuator ShNode has an actor, then turn_on will generate that dispatch MQTT message (not implemented yet).
 4) Fixed a mis-categorization in the input_data (the primary_scada listed as a boolean actuator)
 5) Reworked the structure of the primary_scada so that turn_on() and turn_off call an ShNode, not a driver or a component. The primary_scada main logic should reference all parts of the system as ShNodes.