### PR TITLE
MVP sense and publish water temp

### DIFF
--- a/gw_spaceheat/actors/atn/atn.py
+++ b/gw_spaceheat/actors/atn/atn.py
@@ -1,14 +1,9 @@
 
-from curses.ascii import GS
-import paho.mqtt.client as mqtt
-import time
-import json
-from typing import List
 from actors.atn.atn_base import Atn_Base
 from data_classes.sh_node import ShNode
 
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import  GtTelemetry100_Maker, GtTelemetry100
-from schema.gs.gs_pwr_1_0_0_maker import GsPwr100_Maker, GsPwr100
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1_maker import  GtTelemetry101
+from schema.gs.gs_pwr_1_0_0_maker import GsPwr100
 
 class Atn(Atn_Base):
     def __init__(self, node: ShNode):
@@ -25,7 +20,7 @@ class Atn(Atn_Base):
         self.power = payload.Power
         self.screen_print(f"Power is {self.power}")
 
-    def gt_telemetry_100_from_primaryscada(self, payload: GtTelemetry100):
+    def gt_telemetry_100_from_primaryscada(self, payload: GtTelemetry101):
         self.screen_print(f"Got {payload}")
 
     @property

--- a/gw_spaceheat/actors/atn/atn_base.py
+++ b/gw_spaceheat/actors/atn/atn_base.py
@@ -8,7 +8,7 @@ from actors.actor_base import ActorBase
 from actors.mqtt_utils import Subscription, QOS
 
 
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import  GtTelemetry100_Maker, GtTelemetry100
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1_maker import  GtTelemetry101_Maker, GtTelemetry101
 from schema.gs.gs_pwr_1_0_0_maker import GsPwr100_Maker, GsPwr100
 
 
@@ -18,14 +18,14 @@ class Atn_Base(ActorBase):
     
     def subscriptions(self) -> List[Subscription]:
         return [Subscription(Topic=f'{self.my_scada.alias}/{GsPwr100_Maker.mp_alias}',Qos=QOS.AtMostOnce),
-                Subscription(Topic=f'{self.my_scada.alias}/{GtTelemetry100_Maker.mp_alias}',Qos=QOS.AtLeastOnce)]
+                Subscription(Topic=f'{self.my_scada.alias}/{GtTelemetry101_Maker.mp_alias}',Qos=QOS.AtLeastOnce)]
 
     def on_message(self, client, userdata, message):
         if message.topic == f'{self.my_scada.alias}/{GsPwr100_Maker.mp_alias}':
             payload = GsPwr100_Maker.binary_to_type(message.payload)
             self.gs_pwr_100_from_primaryscada(payload)
         # Not implemented
-        # elif message.topic == f'{self.my_scada.alias}/{GtTelemetry100_Maker.mp_alias}':
+        # elif message.topic == f'{self.my_scada.alias}/{GtTelemetry101_Maker.mp_alias}':
             # self.gt_telemetry_100_from_primaryscada(payload)
         else:
             self.screen_print(f"{message.topic} subscription not implemented!")
@@ -35,7 +35,7 @@ class Atn_Base(ActorBase):
         raise NotImplementedError
      
     @abstractmethod
-    def gt_telemetry_100_from_primaryscada(self, payload: GtTelemetry100):
+    def gt_telemetry_100_from_primaryscada(self, payload: GtTelemetry101):
         raise NotImplementedError
     
     @abstractproperty

--- a/gw_spaceheat/actors/power_meter/power_meter.py
+++ b/gw_spaceheat/actors/power_meter/power_meter.py
@@ -1,13 +1,12 @@
-from typing import List
-from actors.power_meter.power_meter_base import Power_Meter_Base
-from actors.primary_scada.primary_scada_base import PrimaryScadaBase
+
+from actors.power_meter.power_meter_base import PowerMeterBase
 from data_classes.sh_node import ShNode
 from schema.gs.gs_pwr_1_0_0_maker import GsPwr100_Maker, GsPwr100
 
 
-class Power_Meter(Power_Meter_Base):
+class PowerMeter(PowerMeterBase):
     def __init__(self, node: ShNode):
-        super(Power_Meter, self).__init__(node=node)
+        super(PowerMeter, self).__init__(node=node)
         self.consume_thread.start()
         self.total_power_w = 4230
 

--- a/gw_spaceheat/actors/power_meter/power_meter_base.py
+++ b/gw_spaceheat/actors/power_meter/power_meter_base.py
@@ -1,11 +1,7 @@
-from abc import abstractmethod
-import paho.mqtt.client as mqtt
-
 from typing import List
 from actors.actor_base import ActorBase
 from data_classes.sh_node import ShNode
 from actors.mqtt_utils import Subscription, QOS
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import  GtTelemetry100_Maker, GtTelemetry100
 from schema.gs.gs_pwr_1_0_0_maker import GsPwr100_Maker, GsPwr100
 
 

--- a/gw_spaceheat/actors/power_meter/power_meter_base.py
+++ b/gw_spaceheat/actors/power_meter/power_meter_base.py
@@ -9,9 +9,9 @@ from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import  GtTelemetry100_Make
 from schema.gs.gs_pwr_1_0_0_maker import GsPwr100_Maker, GsPwr100
 
 
-class Power_Meter_Base(ActorBase):
+class PowerMeterBase(ActorBase):
     def __init__(self, node: ShNode):
-        super(Power_Meter_Base, self).__init__(node=node)
+        super(PowerMeterBase, self).__init__(node=node)
 
     def subscriptions(self) -> List[Subscription]:
         return []

--- a/gw_spaceheat/actors/primary_scada/primary_scada.py
+++ b/gw_spaceheat/actors/primary_scada/primary_scada.py
@@ -3,7 +3,7 @@ from actors.primary_scada.primary_scada_base import PrimaryScadaBase
 from data_classes.sh_node import ShNode
 from data_classes.components.boolean_actuator_component import BooleanActuatorComponent 
 from drivers.boolean_actuator.boolean_actuator_driver import BooleanActuatorDriver
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import GtTelemetry100
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1_maker import GtTelemetry101
 from schema.gs.gs_pwr_1_0_0_maker import GsPwr100_Maker, GsPwr100
 from drivers.boolean_actuator.ncd__pr814spst__boolean_actuator_driver import NcdPr814Spst_BooleanActuatorDriver
 from drivers.boolean_actuator.gridworks_simbool30amprelay__boolean_actuator_driver import GridworksSimBool30AmpRelay_BooleanActuatorDriver
@@ -54,7 +54,7 @@ class PrimaryScada(PrimaryScadaBase):
         self.total_power_w = payload.Power
         self.publish()
     
-    def gt_telemetry_100_received(self, payload: GtTelemetry100, from_node: ShNode):
+    def gt_telemetry_100_received(self, payload: GtTelemetry101, from_node: ShNode):
         self.screen_print(f"Got {payload} from {from_node.alias}")
 
     @property

--- a/gw_spaceheat/actors/primary_scada/primary_scada.py
+++ b/gw_spaceheat/actors/primary_scada/primary_scada.py
@@ -2,12 +2,12 @@ from typing import List, Dict
 from actors.primary_scada.primary_scada_base import PrimaryScadaBase
 from data_classes.sh_node import ShNode
 from data_classes.components.boolean_actuator_component import BooleanActuatorComponent 
-from drivers.boolean_actuator.boolean_actuator_base import BooleanActuator
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import GtTelemetry100, GtTelemetry100_Maker
+from drivers.boolean_actuator.boolean_actuator_driver import BooleanActuatorDriver
+from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import GtTelemetry100
 from schema.gs.gs_pwr_1_0_0_maker import GsPwr100_Maker, GsPwr100
-from drivers.boolean_actuator.ncd__pr8_14_spst__boolean_actuator import Ncd__Pr8_14_Spst__BooleanActuator
-from drivers.boolean_actuator.gridworks_simbool30amprelay__boolean_actuator import Gridworks__SimBool30AmpRelay__BooleanActuator
-from drivers.boolean_actuator.boolean_actuator_base import BooleanActuator
+from drivers.boolean_actuator.ncd__pr814spst__boolean_actuator_driver import NcdPr814Spst_BooleanActuatorDriver
+from drivers.boolean_actuator.gridworks_simbool30amprelay__boolean_actuator_driver import GridworksSimBool30AmpRelay_BooleanActuatorDriver
+
 
 class PrimaryScada(PrimaryScadaBase):
     def __init__(self, node: ShNode):
@@ -15,7 +15,7 @@ class PrimaryScada(PrimaryScadaBase):
         self.power = 0
         self.consume_thread.start()
         self.total_power_w = 0
-        self.driver: Dict[ShNode, BooleanActuator] = {}
+        self.driver: Dict[ShNode, BooleanActuatorDriver] = {}
         self.set_actuator_components()
         
         
@@ -29,18 +29,18 @@ class PrimaryScada(PrimaryScadaBase):
 
         self.boost_actuator = ShNode.by_alias['a.elt1.relay']
         if self.boost_actuator.primary_component.make_model == 'NCD__PR8-14-SPST':
-            self.driver[self.boost_actuator] =  Ncd__Pr8_14_Spst__BooleanActuator(component=self.boost_actuator.primary_component)
+            self.driver[self.boost_actuator] =  NcdPr814Spst_BooleanActuatorDriver(component=self.boost_actuator.primary_component)
         elif self.boost_actuator.primary_component.make_model == 'GridWorks__SimBool30AmpRelay':
-            self.driver[self.boost_actuator] = Gridworks__SimBool30AmpRelay__BooleanActuator(component=self.boost_actuator.primary_component)
+            self.driver[self.boost_actuator] = GridworksSimBool30AmpRelay_BooleanActuatorDriver(component=self.boost_actuator.primary_component)
         else:
             raise NotImplementedError(f"No driver yet for {self.boost_actuator.primary_component.make_model}")
 
         self.pump_actuator = ShNode.by_alias['a.tank.out.pump.relay']
 
         if self.pump_actuator.primary_component.make_model == 'NCD__PR8-14-SPST':
-            self.driver[self.pump_actuator] =  Ncd__Pr8_14_Spst__BooleanActuator(component=self.pump_actuator.primary_component)
+            self.driver[self.pump_actuator] =  NcdPr814Spst_BooleanActuatorDriver(component=self.pump_actuator.primary_component)
         elif self.pump_actuator.primary_component.make_model == 'GridWorks__SimBool30AmpRelay':
-            self.driver[self.pump_actuator] = Gridworks__SimBool30AmpRelay__BooleanActuator(component=self.pump_actuator.primary_component)
+            self.driver[self.pump_actuator] = GridworksSimBool30AmpRelay_BooleanActuatorDriver(component=self.pump_actuator.primary_component)
         else:
             raise NotImplementedError(f"No driver yet for {self.pump_actuator.primary_component.make_model}")
         

--- a/gw_spaceheat/actors/primary_scada/primary_scada_base.py
+++ b/gw_spaceheat/actors/primary_scada/primary_scada_base.py
@@ -4,7 +4,7 @@ from typing import List
 from actors.actor_base import ActorBase
 from data_classes.sh_node import ShNode
 from actors.mqtt_utils import Subscription, QOS
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import  GtTelemetry100_Maker, GtTelemetry100
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1_maker import  GtTelemetry101_Maker, GtTelemetry101
 from schema.gs.gs_pwr_1_0_0_maker import GsPwr100_Maker, GsPwr100
 
 
@@ -14,8 +14,8 @@ class PrimaryScadaBase(ActorBase):
 
     def subscriptions(self) -> List[Subscription]:
         return [Subscription(Topic=f'{self.my_meter.alias}/{GsPwr100_Maker.mp_alias}',Qos=QOS.AtMostOnce),
-                Subscription(Topic=f'a.tank.out.flowmeter1/{GtTelemetry100_Maker.mp_alias}',Qos=QOS.AtLeastOnce),
-                Subscription(Topic=f'a.tank.temp0/{GtTelemetry100_Maker.mp_alias}',Qos=QOS.AtLeastOnce)]
+                Subscription(Topic=f'a.tank.out.flowmeter1/{GtTelemetry101_Maker.mp_alias}',Qos=QOS.AtLeastOnce),
+                Subscription(Topic=f'a.tank.temp0/{GtTelemetry101_Maker.mp_alias}',Qos=QOS.AtLeastOnce)]
 
     def on_message(self, client, userdata, message):
         try:
@@ -28,8 +28,8 @@ class PrimaryScadaBase(ActorBase):
             # self.raw_payload = message.payload
             payload = GsPwr100_Maker.binary_to_type(message.payload)
             self.gs_pwr_100_from_powermeter(payload)
-        elif mp_alias == GtTelemetry100_Maker.mp_alias:
-            payload = GtTelemetry100_Maker.create_payload_from_camel_dict(json.loads(message.payload))
+        elif mp_alias == GtTelemetry101_Maker.mp_alias:
+            payload = GtTelemetry101_Maker.camel_dict_to_type(json.loads(message.payload))
             from_node = ShNode.by_alias[from_alias]
             self.gt_telemetry_100_received(payload=payload, from_node=from_node)
         else:
@@ -40,7 +40,7 @@ class PrimaryScadaBase(ActorBase):
         raise NotImplementedError
 
     @abstractmethod
-    def gt_telemetry_100_received(self, payload: GtTelemetry100, from_node: ShNode):
+    def gt_telemetry_100_received(self, payload: GtTelemetry101, from_node: ShNode):
         raise NotImplementedError
 
     def publish_gs_pwr(self, payload: GsPwr100):

--- a/gw_spaceheat/actors/primary_scada/primary_scada_base.py
+++ b/gw_spaceheat/actors/primary_scada/primary_scada_base.py
@@ -14,7 +14,8 @@ class PrimaryScadaBase(ActorBase):
 
     def subscriptions(self) -> List[Subscription]:
         return [Subscription(Topic=f'{self.my_meter.alias}/{GsPwr100_Maker.mp_alias}',Qos=QOS.AtMostOnce),
-                Subscription(Topic=f'a.tank.out.flowmeter1/{GtTelemetry100_Maker.mp_alias}',Qos=QOS.AtLeastOnce)]
+                Subscription(Topic=f'a.tank.out.flowmeter1/{GtTelemetry100_Maker.mp_alias}',Qos=QOS.AtLeastOnce),
+                Subscription(Topic=f'a.tank.temp0/{GtTelemetry100_Maker.mp_alias}',Qos=QOS.AtLeastOnce)]
 
     def on_message(self, client, userdata, message):
         try:

--- a/gw_spaceheat/actors/sensor/pipe_flow_meter.py
+++ b/gw_spaceheat/actors/sensor/pipe_flow_meter.py
@@ -14,9 +14,9 @@ from schema.gt.gt_telemetry.gt_telemetry_1_0_0_base import TelemetryName
 from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import GtTelemetry100, GtTelemetry100_Maker
 
 
-class Pipe_Flow_Meter(SensorBase):
+class PipeFlowMeter(SensorBase):
     def __init__(self, node: ShNode):
-        super(Pipe_Flow_Meter, self).__init__(node=node)   
+        super(PipeFlowMeter, self).__init__(node=node)   
         self.water_flow_gpm = 0
         self.screen_print('hi')
         self.consume_thread.start()

--- a/gw_spaceheat/actors/sensor/pipe_flow_meter.py
+++ b/gw_spaceheat/actors/sensor/pipe_flow_meter.py
@@ -10,8 +10,8 @@ from data_classes.cacs.sensor_cac import SensorCac
 from data_classes.sh_node import ShNode
 from data_classes.sensor_type_static import WATER_FLOW_METER
 from data_classes.sh_node_role_static import SENSOR
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_base import TelemetryName
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import GtTelemetry100, GtTelemetry100_Maker
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1_maker import GtTelemetry101_Maker
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1_base import TelemetryName
 
 
 class PipeFlowMeter(SensorBase):
@@ -24,10 +24,10 @@ class PipeFlowMeter(SensorBase):
     def publish(self):
         self.water_flow_gpm += 100
         self.water_flow_gpm = self.water_flow_gpm % 3000
-        payload = GtTelemetry100_Maker(name=TelemetryName.WATER_FLOW_GPM_TIMES_100.value,
+        payload = GtTelemetry101_Maker(name=TelemetryName.WATER_FLOW_GPM_TIMES_100.value,
                         value=int(self.water_flow_gpm*100),
                         scada_read_time_unix_ms=int(time.time()*1000)).type
-        self.publish_gt_telemetry_1_0_0(payload)
+        self.publish_gt_telemetry_1_0_1(payload)
         
     def consume(self):
         pass

--- a/gw_spaceheat/actors/sensor/sensor_base.py
+++ b/gw_spaceheat/actors/sensor/sensor_base.py
@@ -6,7 +6,7 @@ from data_classes.sh_node import ShNode
 from data_classes.sensor_type_static import WATER_FLOW_METER
 from data_classes.sh_node_role_static import SENSOR
 from actors.mqtt_utils import Subscription, QOS
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import GtTelemetry100, GtTelemetry100_Maker
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1_maker import GtTelemetry101, GtTelemetry101_Maker
 
 
 class SensorBase(ActorBase):
@@ -19,8 +19,8 @@ class SensorBase(ActorBase):
     def on_message(self, client, userdata, message):
         self.screen_print(f"{message.topic} subscription not implemented!")
     
-    def publish_gt_telemetry_1_0_0(self, payload: GtTelemetry100):
-        topic = f'{self.node.alias}/{GtTelemetry100_Maker.mp_alias}'
+    def publish_gt_telemetry_1_0_1(self, payload: GtTelemetry101):
+        topic = f'{self.node.alias}/{GtTelemetry101_Maker.mp_alias}'
         self.publish_client.publish(topic=topic, 
                             payload=json.dumps(payload.asdict()),
                             qos = QOS.AtLeastOnce.value,

--- a/gw_spaceheat/actors/sensor/tank_water_temp_sensor.py
+++ b/gw_spaceheat/actors/sensor/tank_water_temp_sensor.py
@@ -1,0 +1,59 @@
+from calendar import c
+import time
+import threading
+from typing import Dict
+from actors.sensor.sensor_base import SensorBase
+
+from data_classes.components.sensor_component import SensorComponent
+from data_classes.cacs.temp_sensor_cac import TempSensorCac
+from data_classes.sh_node import ShNode
+from data_classes.sh_node_role_static import SENSOR
+from schema.gt.gt_telemetry.gt_telemetry_1_0_0_base import TelemetryName
+from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import GtTelemetry100, GtTelemetry100_Maker
+from drivers.temp_sensor.temp_sensor_driver import TempSensorDriver
+from drivers.temp_sensor.adafruit_642__temp_sensor_driver import Adafruit642_TempSensorDriver
+from drivers.temp_sensor.gridworks_water_temp_high_precision_temp_sensor_driver import GridworksWaterTempSensorHighPrecision_TempSensorDriver
+
+
+class TankWaterTempSensor(SensorBase):
+    def __init__(self, node: ShNode):
+        super(TankWaterTempSensor, self).__init__(node=node)   
+        self.temp = 67123
+        self.screen_print('hi')
+        self.driver: TempSensorDriver = None
+        self.cac: TempSensorCac = self.node.primary_component.cac
+        self.set_driver()
+        self.telemetry_name: TelemetryName = None
+        self.set_telemetry_name()
+        self.consume_thread.start()
+        self.sensing_thread = threading.Thread(target=self.main)
+        self.sensing_thread.start()
+
+    def set_driver(self):
+        if self.node.primary_component.cac.make_model == 'Adafruit__642':
+            self.driver = Adafruit642_TempSensorDriver(component=self.node.primary_component)
+        elif self.node.primary_component.cac.make_model == 'GridWorks__WaterTempHighPrecision':
+            self.driver = GridworksWaterTempSensorHighPrecision_TempSensorDriver(component=self.node.primary_component)
+
+    def set_telemetry_name(self):
+        if self.cac.temp_unit == 'F' and self.cac.precision_exponent == 3:
+            self.telemetry_name = TelemetryName.WATER_TEMP_F_TIMES_1000
+        elif self.cac.temp_unit == 'C' and self.cac.precision_exponent == 3:
+            self.telemetry_name = TelemetryName.WATER_TEMP_C_TIMES_1000
+        else:
+            raise Exception(f"TelemetryName for {self.cac.temp_unit} and precision exponent of {self.cac.precision_exponent} not set yet!")
+
+    def publish(self):
+        payload = GtTelemetry100_Maker(name=self.telemetry_name.value,
+                        value=int(self.temp),
+                        scada_read_time_unix_ms=int(time.time()*1000)).type
+        self.publish_gt_telemetry_1_0_0(payload)
+        
+    def consume(self):
+        pass
+
+    def main(self):
+        while True:
+            self.temp = self.driver.read_temp()
+            self.screen_print(f"Just read temp {self.temp/(10**self.cac.precision_exponent)} {self.cac.temp_unit}")
+            self.publish()

--- a/gw_spaceheat/actors/sensor/tank_water_temp_sensor.py
+++ b/gw_spaceheat/actors/sensor/tank_water_temp_sensor.py
@@ -8,8 +8,8 @@ from data_classes.components.sensor_component import SensorComponent
 from data_classes.cacs.temp_sensor_cac import TempSensorCac
 from data_classes.sh_node import ShNode
 from data_classes.sh_node_role_static import SENSOR
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_base import TelemetryName
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_maker import GtTelemetry100, GtTelemetry100_Maker
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1_base import TelemetryName
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1_maker import GtTelemetry101_Maker
 from drivers.temp_sensor.temp_sensor_driver import TempSensorDriver
 from drivers.temp_sensor.adafruit_642__temp_sensor_driver import Adafruit642_TempSensorDriver
 from drivers.temp_sensor.gridworks_water_temp_high_precision_temp_sensor_driver import GridworksWaterTempSensorHighPrecision_TempSensorDriver
@@ -44,10 +44,10 @@ class TankWaterTempSensor(SensorBase):
             raise Exception(f"TelemetryName for {self.cac.temp_unit} and precision exponent of {self.cac.precision_exponent} not set yet!")
 
     def publish(self):
-        payload = GtTelemetry100_Maker(name=self.telemetry_name.value,
+        payload = GtTelemetry101_Maker(name=self.telemetry_name.value,
                         value=int(self.temp),
                         scada_read_time_unix_ms=int(time.time()*1000)).type
-        self.publish_gt_telemetry_1_0_0(payload)
+        self.publish_gt_telemetry_1_0_1(payload)
         
     def consume(self):
         pass

--- a/gw_spaceheat/actors/strategy_switcher.py
+++ b/gw_spaceheat/actors/strategy_switcher.py
@@ -1,15 +1,17 @@
 from actors.primary_scada.primary_scada import PrimaryScada
-from actors.sensor.pipe_flow_meter import Pipe_Flow_Meter
-from actors.power_meter.power_meter import Power_Meter
+from actors.sensor.pipe_flow_meter import PipeFlowMeter
+from actors.sensor.tank_water_temp_sensor import TankWaterTempSensor
+from actors.power_meter.power_meter import PowerMeter
 from actors.atn.atn import Atn
 
 
 def main(python_actor_name):
     switcher = {}
     switcher['PrimaryScada'] = PrimaryScada
-    switcher['PipeFlowMeter'] = Pipe_Flow_Meter
-    switcher['PowerMeter'] = Power_Meter
+    switcher['PipeFlowMeter'] = PipeFlowMeter
+    switcher['PowerMeter'] = PowerMeter
     switcher['Atn'] = Atn
+    switcher['TankWaterTempSensor'] = TankWaterTempSensor
     func = switcher.get(python_actor_name,
                         lambda x: f"No python implementation for strategy {python_actor_name}")
     return func, switcher.keys()

--- a/gw_spaceheat/data_classes/cacs/boolean_actuator_cac.py
+++ b/gw_spaceheat/data_classes/cacs/boolean_actuator_cac.py
@@ -10,6 +10,7 @@ class BooleanActuatorCac(ComponentAttributeClass):
     base_props = []
     base_props.append('component_attribute_class_id')
     base_props.append('make_model')
+    base_props.append('display_name')
     base_props.append('component_type_value')
 
     
@@ -25,18 +26,17 @@ class BooleanActuatorCac(ComponentAttributeClass):
     def __init__(self,
             component_attribute_class_id: Optional[str] = None,
             actuator_type_value: Optional[str] = None,
+            display_name: Optional[str] = None,
             make_model: Optional[str] = None):
         super(BooleanActuatorCac, self).__init__(component_attribute_class_id=component_attribute_class_id,
                         make_model=make_model,
+                        display_name=display_name,
                         component_type_value=actuator_type_value)
         self.actuator_type_value = actuator_type_value
     
     def __repr__(self):
-        return f'SensorCac ({self.display_name}) {self.component_attribute_class_id}'
-
-    @property
-    def display_name(self) -> str:
-        return f'{self.actuator_type_value} {self.make_model}'
+        val = f'PipeFlowSensorCac {self.make_model}: {self.display_name}'
+        return val
 
     @classmethod
     def check_uniqueness_of_primary_key(cls, attributes):

--- a/gw_spaceheat/data_classes/cacs/boolean_actuator_cac.py
+++ b/gw_spaceheat/data_classes/cacs/boolean_actuator_cac.py
@@ -54,10 +54,3 @@ class BooleanActuatorCac(ComponentAttributeClass):
     def check_initialization_consistency(cls, attributes):
        BooleanActuatorCac.check_uniqueness_of_primary_key(attributes)
        BooleanActuatorCac.check_existence_of_certain_attributes(attributes)
-    
-    def check_immutability_for_existing_attributes(self, new_attributes):
-        if new_attributes['component_attribute_class_id'] != self.component_attribute_class_id:
-            raise DcError('component_attribute_class_id is Immutable')
-        if new_attributes['actuator_type_value'] != self.actuator_type_value:
-            raise DcError(f"actuator_type_value is Immutable. Not changing {self.display_name}"
-                                    f" from {self.actuator_type_value} to {new_attributes['actuator_type_value']}")

--- a/gw_spaceheat/data_classes/cacs/electric_heater_cac.py
+++ b/gw_spaceheat/data_classes/cacs/electric_heater_cac.py
@@ -57,13 +57,6 @@ class ElectricHeaterCac(ComponentAttributeClass):
         ElectricHeaterCac.check_uniqueness_of_primary_key(attributes)
         ElectricHeaterCac.check_existence_of_certain_attributes(attributes)
     
-    def check_immutability_for_existing_attributes(self, new_attributes):
-        if new_attributes['component_attribute_class_id'] != self.component_attribute_class_id:
-            raise DcError('component_attribute_class_id is Immutable')
-        if new_attributes['electric_heater_type_value'] != self.electric_heater_type_value:
-            raise DcError(f"electric_heater_type_value is Immutable. Not changing {self.display_name}"
-                                    f" from {self.electric_heater_type_value} to {new_attributes['electric_heater_type_value']}")
-    
     @property
     def electric_heater_type(self) -> ElectricHeaterType:
         if self.electric_heater_type_value not in PlatformElectricHeaterType.keys():

--- a/gw_spaceheat/data_classes/cacs/electric_heater_cac.py
+++ b/gw_spaceheat/data_classes/cacs/electric_heater_cac.py
@@ -13,6 +13,7 @@ class ElectricHeaterCac(ComponentAttributeClass):
     base_props = []
     base_props.append('component_attribute_class_id')
     base_props.append('make_model')
+    base_props.append('display_name')
     base_props.append('electric_heater_type_value')
     
     def __new__(cls, component_attribute_class_id, *args, **kwargs):
@@ -27,18 +28,17 @@ class ElectricHeaterCac(ComponentAttributeClass):
     def __init__(self,
             component_attribute_class_id: Optional[str] = None,
             electric_heater_type_value: Optional[str] = None, 
-            make_model: Optional[str] = None):
+            make_model: Optional[str] = None,
+            display_name: Optional[str] = None):
         super(ElectricHeaterCac, self).__init__(component_attribute_class_id=component_attribute_class_id,
                         make_model=make_model,
+                        display_name=display_name,
                         component_type_value=electric_heater_type_value)
         self.electric_heater_type_value=electric_heater_type_value
 
     def __repr__(self):
         return f'ElectricHeaterCac ({self.display_name})) {self.component_attribute_class_id}'
 
-    @property
-    def display_name(self) -> str:
-        return f'{self.electric_heater_type_value} {self.make_model}'
 
     @classmethod
     def check_uniqueness_of_primary_key(cls, attributes):

--- a/gw_spaceheat/data_classes/cacs/electric_meter_cac.py
+++ b/gw_spaceheat/data_classes/cacs/electric_meter_cac.py
@@ -1,0 +1,43 @@
+""" TempSensorCac Class Definition """
+
+from typing import Dict, Optional
+from data_classes.cacs.sensor_cac import SensorCac
+from data_classes.component_attribute_class import ComponentAttributeClass
+
+class ElectricMeterCac(SensorCac):
+    by_id: Dict[str, SensorCac] = {}
+
+    base_props = []
+    base_props.append('component_attribute_class_id')
+    base_props.append('make_model')
+    base_props.append('display_name')
+    base_props.append('sensor_type_value')
+    base_props.append('comms_method')
+
+    def __new__(cls, component_attribute_class_id, *args, **kwargs):
+        if component_attribute_class_id in ComponentAttributeClass.by_id.keys():
+            if not isinstance(ComponentAttributeClass.by_id[component_attribute_class_id], cls):
+                raise Exception(f"Id already exists for {ComponentAttributeClass.by_id[component_attribute_class_id]}, not a temp sensor!")
+            return ComponentAttributeClass.by_id[component_attribute_class_id]
+        instance = super().__new__(cls,component_attribute_class_id=component_attribute_class_id)
+        ComponentAttributeClass.by_id[component_attribute_class_id] = instance
+        return instance
+
+    def __init__(self,
+            component_attribute_class_id: Optional[str] = None,
+            sensor_type_value: Optional[str] = None,
+            display_name: Optional[str] = None,
+            make_model: Optional[str] = None,
+            comms_method: Optional[str] = None):
+        super(ElectricMeterCac, self).__init__(component_attribute_class_id=component_attribute_class_id,
+                        make_model=make_model,
+                        display_name=display_name,
+                        sensor_type_value=sensor_type_value,
+                        comms_method = comms_method)
+
+    def __repr__(self):
+        val = f'SensorCac {self.make_model}: {self.display_name}'
+        if self.comms_method:
+            val += f' Comms method: {self.comms_method}'
+        return val
+    

--- a/gw_spaceheat/data_classes/cacs/pipe_flow_sensor_cac.py
+++ b/gw_spaceheat/data_classes/cacs/pipe_flow_sensor_cac.py
@@ -1,0 +1,48 @@
+""" TempSensorCac Class Definition """
+
+from typing import Dict, Optional
+from data_classes.cacs.sensor_cac import SensorCac
+from data_classes.component_attribute_class import ComponentAttributeClass
+
+class PipeFlowSensorCac(SensorCac):
+    by_id: Dict[str, SensorCac] = {}
+
+    base_props = []
+    base_props.append('component_attribute_class_id')
+    base_props.append('make_model')
+    base_props.append('display_name')
+    base_props.append('sensor_type_value')
+    base_props.append('comms_method')
+    base_props.append('precision_decimals_f')
+
+    def __new__(cls, component_attribute_class_id, *args, **kwargs):
+        if component_attribute_class_id in ComponentAttributeClass.by_id.keys():
+            if not isinstance(ComponentAttributeClass.by_id[component_attribute_class_id], cls):
+                raise Exception(f"Id already exists for {ComponentAttributeClass.by_id[component_attribute_class_id]}, not a temp sensor!")
+            return ComponentAttributeClass.by_id[component_attribute_class_id]
+        instance = super().__new__(cls,component_attribute_class_id=component_attribute_class_id)
+        ComponentAttributeClass.by_id[component_attribute_class_id] = instance
+        return instance
+
+    def __init__(self,
+            component_attribute_class_id: Optional[str] = None,
+            make_model: Optional[str] = None,
+            display_name: Optional[str] = None,
+            sensor_type_value: Optional[str] = None,
+            comms_method: Optional[str] = None,
+            precision_decimals_f: Optional[int] = None):
+        super(PipeFlowSensorCac, self).__init__(component_attribute_class_id=component_attribute_class_id,
+                        make_model=make_model,
+                        display_name=display_name,
+                        sensor_type_value=sensor_type_value,
+                        comms_method = comms_method)
+        self.precision_decimals_f = precision_decimals_f
+
+    def __repr__(self):
+        val = f'PipeFlowSensorCac {self.make_model}: {self.display_name}'
+        if self.comms_method:
+            val += f' Comms method: {self.comms_method}'
+        if self.precision_decimals_f:
+            val += f' Precision decimals: {self.precision_decimals_f} F'
+        return val
+    

--- a/gw_spaceheat/data_classes/cacs/sensor_cac.py
+++ b/gw_spaceheat/data_classes/cacs/sensor_cac.py
@@ -13,7 +13,10 @@ class SensorCac(ComponentAttributeClass):
     base_props = []
     base_props.append('component_attribute_class_id')
     base_props.append('make_model')
+    base_props.append('display_name')
     base_props.append('sensor_type_value')
+    base_props.append('comms_method') 
+        
     
     def __new__(cls, component_attribute_class_id, *args, **kwargs):
         if component_attribute_class_id in ComponentAttributeClass.by_id.keys():
@@ -26,20 +29,23 @@ class SensorCac(ComponentAttributeClass):
 
     def __init__(self,
             component_attribute_class_id: Optional[str] = None,
+            display_name: Optional[str] = None,
             sensor_type_value: Optional[str] = None,
-            make_model: Optional[str] = None):
+            make_model: Optional[str] = None,
+            comms_method: Optional[str] = None):
         super(SensorCac, self).__init__(component_attribute_class_id=component_attribute_class_id,
                         make_model=make_model,
+                        display_name=display_name,
                         component_type_value=sensor_type_value)
         self.sensor_type_value = sensor_type_value
+        self.comms_method = comms_method
 
     def __repr__(self):
-        return f'SensorCac ({self.display_name})) {self.component_attribute_class_id}'
+        val = f'SensorCac {self.make_model}: {self.display_name}'
+        if self.comms_method:
+            val += f' Comms method: {self.comms_method}'
+        return val
     
-    @property
-    def display_name(self) -> str:
-        return f'{self.sensor_type_value} {self.make_model}'
-
     @classmethod
     def check_uniqueness_of_primary_key(cls, attributes):
         if attributes['component_attribute_class_id'] in ComponentAttributeClass.by_id.keys():

--- a/gw_spaceheat/data_classes/cacs/sensor_cac.py
+++ b/gw_spaceheat/data_classes/cacs/sensor_cac.py
@@ -49,20 +49,17 @@ class SensorCac(ComponentAttributeClass):
     def check_existence_of_certain_attributes(cls, attributes):
         if 'component_attribute_class_id' not in attributes.keys():
             raise DcError('component_attribute_class_id must exist')
+        """if 'make_model' not in attributes.keys():
+            raise DcError(f'make_model must exist for {attributes}')"""
         if 'sensor_type_value' not in attributes.keys():
-            raise DcError('sensor_type_value')
+            raise DcError(f'sensor_type_value must exist for {attributes}')
+        """if 'comms_method' not in attributes.keys():
+            raise DcError(f"comms_method must exist for {attributes}")"""
 
     @classmethod
     def check_initialization_consistency(cls, attributes):
         SensorCac.check_uniqueness_of_primary_key(attributes)
         SensorCac.check_existence_of_certain_attributes(attributes)
-    
-    def check_immutability_for_existing_attributes(self, new_attributes):
-        if new_attributes['component_attribute_class_id'] != self.component_attribute_class_id:
-            raise DcError('component_attribute_class_id is Immutable')
-        if new_attributes['sensor_type_value'] != self.sensor_type_value:
-            raise DcError(f"sensor_type_value is Immutable. Not changing {self.display_name}"
-                                    f" from {self.sensor_type_value} to {new_attributes['sensor_type_value']}")
     
     @property
     def sensor_type(self) -> SensorType:

--- a/gw_spaceheat/data_classes/cacs/temp_sensor_cac.py
+++ b/gw_spaceheat/data_classes/cacs/temp_sensor_cac.py
@@ -1,0 +1,53 @@
+""" TempSensorCac Class Definition """
+
+from typing import Dict, Optional
+from data_classes.cacs.sensor_cac import SensorCac
+from data_classes.component_attribute_class import ComponentAttributeClass
+
+class TempSensorCac(SensorCac):
+    by_id: Dict[str, SensorCac] = {}
+
+    base_props = []
+    base_props.append('component_attribute_class_id')
+    base_props.append('make_model')
+    base_props.append('display_name')
+    base_props.append('sensor_type_value')
+    base_props.append('comms_method')
+    base_props.append('precision_exponent')
+    base_props.append('temp_unit')
+
+    def __new__(cls, component_attribute_class_id, *args, **kwargs):
+        if component_attribute_class_id in ComponentAttributeClass.by_id.keys():
+            if not isinstance(ComponentAttributeClass.by_id[component_attribute_class_id], cls):
+                raise Exception(f"Id already exists for {ComponentAttributeClass.by_id[component_attribute_class_id]}, not a temp sensor!")
+            return ComponentAttributeClass.by_id[component_attribute_class_id]
+        instance = super().__new__(cls,component_attribute_class_id=component_attribute_class_id)
+        ComponentAttributeClass.by_id[component_attribute_class_id] = instance
+        return instance
+
+    def __init__(self,
+            component_attribute_class_id: Optional[str] = None,
+            sensor_type_value: Optional[str] = None,
+            make_model: Optional[str] = None,
+            display_name: Optional[str] = None,
+            comms_method: Optional[str] = None,
+            precision_exponent: Optional[int] = None,
+            temp_unit: Optional[str] = None):
+        super(TempSensorCac, self).__init__(component_attribute_class_id=component_attribute_class_id,
+                        make_model=make_model,
+                        display_name=display_name,
+                        sensor_type_value=sensor_type_value,
+                        comms_method = comms_method)
+        self.precision_exponent = precision_exponent
+        self.temp_unit = temp_unit
+
+    def __repr__(self):
+        val = f'TempSensorCac {self.make_model}: {self.display_name}'
+        if self.comms_method:
+            val += f', Comms method: {self.comms_method}'
+        if self.precision_exponent:
+            val += f', Precision exponent: {self.precision_exponent}'
+        if self.temp_unit:
+            val += f', Temp unit: {self.temp_unit}'
+        return val
+    

--- a/gw_spaceheat/data_classes/component.py
+++ b/gw_spaceheat/data_classes/component.py
@@ -55,18 +55,4 @@ class Component(ABC, StreamlinedSerializerMixin):
         Component.check_uniqueness_of_primary_key(attributes)
         Component.check_existence_of_certain_attributes(attributes)
 
-
-    def check_immutability_for_existing_attributes(self, new_attributes):
-        if new_attributes['component_id'] != self.component_id:
-            raise DcError('component_id is Immutable')
-        if new_attributes['component_attribute_class_id'] != self.component_attribute_class_id:
-            raise DcError('component_attribute_class_id is Immutable')
-
-    def check_update_consistency(self, new_attributes):
-        self.check_immutability_for_existing_attributes(new_attributes)
-
-    @property
-    def cac(self) -> ComponentAttributeClass:
-        if self.component_attribute_class_id not in ComponentAttributeClass.by_id.keys():
-            raise DataClassLoadingError(f"ActuatorCacId {self.component_attribute_class_id} not loaded yet")
-        return ComponentAttributeClass.by_id[self.component_attribute_class_id]
+    

--- a/gw_spaceheat/data_classes/component.py
+++ b/gw_spaceheat/data_classes/component.py
@@ -15,6 +15,7 @@ class Component(ABC, StreamlinedSerializerMixin):
     base_props.append('component_id')
     base_props.append('display_name')
     base_props.append('component_attribute_class_id')
+    base_props.append('hw_uid')
 
 
     def __new__(cls, component_id, *args, **kwargs):
@@ -28,10 +29,12 @@ class Component(ABC, StreamlinedSerializerMixin):
     def __init__(self,
                  component_id: Optional[str] = None,
                  display_name: Optional[str] = None,
-                 component_attribute_class_id: Optional[str] = None):
+                 component_attribute_class_id: Optional[str] = None,
+                 hw_uid: Optional[str] = None):
         self.component_id = component_id
         self.display_name = display_name
         self.component_attribute_class_id = component_attribute_class_id
+        self.hw_uid = hw_uid
 
     def __repr__(self):
         return f'Component {self.display_name}'

--- a/gw_spaceheat/data_classes/component.py
+++ b/gw_spaceheat/data_classes/component.py
@@ -3,8 +3,7 @@
 from abc import ABC
 from typing import Optional
 
-from data_classes.component_attribute_class import ComponentAttributeClass
-from data_classes.errors import DataClassLoadingError, DcError
+from data_classes.errors import DcError
 from data_classes.mixin import StreamlinedSerializerMixin
 
 

--- a/gw_spaceheat/data_classes/component_attribute_class.py
+++ b/gw_spaceheat/data_classes/component_attribute_class.py
@@ -11,6 +11,7 @@ class ComponentAttributeClass(ABC, StreamlinedSerializerMixin):
     base_props.append('component_attribute_class_id')
     base_props.append('make_model')
     base_props.append('component_type_value')
+    base_props.append('display_name')
 
 
     def __new__(cls, component_attribute_class_id, *args, **kwargs):
@@ -24,14 +25,15 @@ class ComponentAttributeClass(ABC, StreamlinedSerializerMixin):
     def __init__(self,
             component_attribute_class_id: Optional[str] = None,
             make_model: Optional[str] = None,
-            component_type_value: Optional[str] = None):
+            component_type_value: Optional[str] = None,
+            display_name: Optional[str] = None):
         self.component_attribute_class_id = component_attribute_class_id
         self.make_model = make_model
         self.component_type_value = component_type_value
+        self.display_name = display_name
 
-    @property
-    def display_name(self) -> str:
-        return f'{self.make_model} (id {self.component_attribute_class_id})'
+    def __repr__(self):
+        return f'MakeModel {self.make_model}: {self.display_name}'
 
     @classmethod
     def check_uniqueness_of_primary_key(cls, attributes):

--- a/gw_spaceheat/data_classes/component_attribute_class.py
+++ b/gw_spaceheat/data_classes/component_attribute_class.py
@@ -41,11 +41,3 @@ class ComponentAttributeClass(ABC, StreamlinedSerializerMixin):
     @classmethod
     def check_initialization_consistency(cls, attributes):
         ComponentAttributeClass.check_uniqueness_of_primary_key(attributes)
-    
-    def check_immutability_for_existing_attributes(self, new_attributes):
-        if new_attributes['component_attribute_class_id'] != self.component_attribute_class_id:
-            raise DcError('component_attribute_class_id is Immutable')
-        if new_attributes['make_model'] != self.make_model:
-            raise DcError('make_model is Immutable')  
-        if new_attributes['component_type_value'] != self.component_type_value:
-            raise DcError(f"component_type_value is Immutable! Cannot change from {self.component_type_value} to {new_attributes['component_type_value']}")

--- a/gw_spaceheat/data_classes/component_type.py
+++ b/gw_spaceheat/data_classes/component_type.py
@@ -1,0 +1,27 @@
+""" ComponentType Class Definition """
+
+from data_classes.component_type_base import ComponentTypeBase
+
+from data_classes.component_sub_category import ComponentSubCategory #
+from data_classes.component_sub_category_static import PlatformComponentSubCategory #
+
+class ComponentType(ComponentTypeBase):
+
+
+    """ Derived attributes """  
+    @property
+    def component_category(self) -> str:
+        raise NotImplementedError
+
+
+    """Static foreign objects referenced by their keys """
+
+    @property
+    def component_sub_category(self):
+        if (self.component_sub_category_value is None):
+            return None
+        elif not(self.component_sub_category_value in PlatformComponentSubCategory.keys()):
+            raise TypeError('ComponentSubCategory must belong to Static List')
+        else:  
+            return PlatformComponentSubCategory[self.component_sub_category_value]      
+

--- a/gw_spaceheat/data_classes/components/boolean_actuator_component.py
+++ b/gw_spaceheat/data_classes/components/boolean_actuator_component.py
@@ -13,6 +13,7 @@ class BooleanActuatorComponent(Component):
     base_props.append('display_name')
     base_props.append('component_attribute_class_id')
     base_props.append('gpio')
+    base_props.append('hw_uid')
 
     def __new__(cls, component_id, *args, **kwargs):
         if component_id in Component.by_id.keys():
@@ -27,10 +28,12 @@ class BooleanActuatorComponent(Component):
                  component_id: Optional[str] = None,
                  display_name: Optional[str] = None,
                  component_attribute_class_id: Optional[str] = None,
-                 gpio: Optional[int] = None):
+                 gpio: Optional[int] = None,
+                 hw_uid: Optional[str] = None):
         super(BooleanActuatorComponent, self).__init__(component_id=component_id,
                             display_name=display_name,
-                            component_attribute_class_id=component_attribute_class_id)
+                            component_attribute_class_id=component_attribute_class_id,
+                            hw_uid=hw_uid)
         self.gpio= gpio
 
     def __repr__(self):

--- a/gw_spaceheat/data_classes/components/electric_meter_component.py
+++ b/gw_spaceheat/data_classes/components/electric_meter_component.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+from data_classes.component import Component
+from data_classes.components.sensor_component import SensorComponent
+from data_classes.errors import DataClassLoadingError
+from data_classes.cacs.electric_meter_cac import ElectricMeterCac
+
+
+class ElectricMeterComponent(SensorComponent):
+    by_id = {}
+    
+    base_props = []
+    base_props.append('component_id')
+    base_props.append('display_name')
+    base_props.append('component_attribute_class_id')
+    base_props.append('hw_uid')
+
+    def __new__(cls, component_id, *args, **kwargs):
+        if component_id in Component.by_id.keys():
+            if not isinstance(Component.by_id[component_id], cls):
+                raise Exception(f"Id already exists, not a temp sensor!")
+            return Component.by_id[component_id]
+        instance = super().__new__(cls,component_id=component_id)
+        Component.by_id[component_id] = instance
+        return instance
+
+    def __init__(self,
+                 component_id: Optional[str] = None,
+                 display_name: Optional[str] = None,
+                 component_attribute_class_id: Optional[str] = None,
+                 hw_uid: Optional[str] = None):
+        super(ElectricMeterComponent, self).__init__(component_id=component_id,
+                            display_name=display_name,
+                            component_attribute_class_id=component_attribute_class_id,
+                            hw_uid=hw_uid)
+
+    @classmethod
+    def check_initialization_consistency(cls, attributes):
+        SensorComponent.check_uniqueness_of_primary_key(attributes)
+        SensorComponent.check_existence_of_certain_attributes(attributes)
+
+    @property
+    def cac(self) -> ElectricMeterCac:
+        if self.component_attribute_class_id not in ElectricMeterCac.by_id.keys():
+            raise DataClassLoadingError(f"ElectricMeterCacId {self.component_attribute_class_id} not loaded yet")
+        return ElectricMeterCac.by_id[self.component_attribute_class_id]
+    

--- a/gw_spaceheat/data_classes/components/pipe_flow_sensor_component.py
+++ b/gw_spaceheat/data_classes/components/pipe_flow_sensor_component.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+from data_classes.component import Component
+from data_classes.components.sensor_component import SensorComponent
+from data_classes.errors import DataClassLoadingError
+from data_classes.cacs.pipe_flow_sensor_cac import PipeFlowSensorCac
+
+
+class PipeFlowSensorComponent(SensorComponent):
+    by_id = {}
+    
+    base_props = []
+    base_props.append('component_id')
+    base_props.append('display_name')
+    base_props.append('component_attribute_class_id')
+    base_props.append('hw_uid')
+
+    def __new__(cls, component_id, *args, **kwargs):
+        if component_id in Component.by_id.keys():
+            if not isinstance(Component.by_id[component_id], cls):
+                raise Exception(f"Id already exists, not a temp sensor!")
+            return Component.by_id[component_id]
+        instance = super().__new__(cls,component_id=component_id)
+        Component.by_id[component_id] = instance
+        return instance
+
+    def __init__(self,
+                 component_id: Optional[str] = None,
+                 display_name: Optional[str] = None,
+                 component_attribute_class_id: Optional[str] = None,
+                 hw_uid: Optional[str] = None):
+        super(PipeFlowSensorComponent, self).__init__(component_id=component_id,
+                            display_name=display_name,
+                            component_attribute_class_id=component_attribute_class_id,
+                            hw_uid=hw_uid)
+
+    @classmethod
+    def check_initialization_consistency(cls, attributes):
+        SensorComponent.check_uniqueness_of_primary_key(attributes)
+        SensorComponent.check_existence_of_certain_attributes(attributes)
+
+    @property
+    def cac(self) -> PipeFlowSensorCac:
+        if self.component_attribute_class_id not in PipeFlowSensorCac.by_id.keys():
+            raise DataClassLoadingError(f"PipeFlowSensorCacId {self.component_attribute_class_id} not loaded yet")
+        return PipeFlowSensorCac.by_id[self.component_attribute_class_id]

--- a/gw_spaceheat/data_classes/components/sensor_component.py
+++ b/gw_spaceheat/data_classes/components/sensor_component.py
@@ -1,8 +1,7 @@
 from typing import Optional
 
-from data_classes.cacs.sensor_cac import SensorCac
 from data_classes.component import Component
-from data_classes.errors import DataClassLoadingError, DcError
+from data_classes.errors import DcError
 
 
 class SensorComponent(Component):
@@ -57,9 +56,3 @@ class SensorComponent(Component):
     def check_initialization_consistency(cls, attributes):
         SensorComponent.check_uniqueness_of_primary_key(attributes)
         SensorComponent.check_existence_of_certain_attributes(attributes)
-
-    @property
-    def cac(self) -> SensorCac:
-        if self.component_attribute_class_id not in SensorCac.by_id.keys():
-            raise DataClassLoadingError(f"SensorCacId {self.component_attribute_class_id} not loaded yet")
-        return SensorCac.by_id[self.component_attribute_class_id]

--- a/gw_spaceheat/data_classes/components/sensor_component.py
+++ b/gw_spaceheat/data_classes/components/sensor_component.py
@@ -12,6 +12,7 @@ class SensorComponent(Component):
     base_props.append('component_id')
     base_props.append('display_name')
     base_props.append('component_attribute_class_id')
+    base_props.append('hw_uid')
 
     def __new__(cls, component_id, *args, **kwargs):
         if component_id in Component.by_id.keys():
@@ -25,14 +26,19 @@ class SensorComponent(Component):
     def __init__(self,
                  component_id: Optional[str] = None,
                  display_name: Optional[str] = None,
-                 component_attribute_class_id: Optional[str] = None):
+                 component_attribute_class_id: Optional[str] = None,
+                 hw_uid: Optional[str] = None):
         super(SensorComponent, self).__init__(component_id=component_id,
                             display_name=display_name,
-                            component_attribute_class_id=component_attribute_class_id)
+                            component_attribute_class_id=component_attribute_class_id,
+                            hw_uid=hw_uid)
 
     def __repr__(self):
-        return f'Component {self.display_name} => Cac {self.cac.display_name}'
-
+        val = f'Component {self.display_name} => Cac {self.cac.display_name}'
+        if self.hw_uid:
+            val += f' Hardware serial number: {self.hw_uid}'
+        return val 
+        
     @classmethod
     def check_uniqueness_of_primary_key(cls, attributes):
         if attributes['component_id'] in cls.by_id.keys():

--- a/gw_spaceheat/data_classes/components/temp_sensor_component.py
+++ b/gw_spaceheat/data_classes/components/temp_sensor_component.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+from data_classes.component import Component
+from data_classes.components.sensor_component import SensorComponent
+from data_classes.errors import DataClassLoadingError
+from data_classes.cacs.temp_sensor_cac import TempSensorCac
+
+class TempSensorComponent(SensorComponent):
+    by_id = {}
+    
+    base_props = []
+    base_props.append('component_id')
+    base_props.append('display_name')
+    base_props.append('component_attribute_class_id')
+    base_props.append('hw_uid')
+
+    def __new__(cls, component_id, *args, **kwargs):
+        if component_id in Component.by_id.keys():
+            if not isinstance(Component.by_id[component_id], cls):
+                raise Exception(f"Id already exists, not a temp sensor!")
+            return Component.by_id[component_id]
+        instance = super().__new__(cls,component_id=component_id)
+        Component.by_id[component_id] = instance
+        return instance
+
+    def __init__(self,
+                 component_id: Optional[str] = None,
+                 display_name: Optional[str] = None,
+                 component_attribute_class_id: Optional[str] = None,
+                 hw_uid: Optional[str] = None):
+        super(TempSensorComponent, self).__init__(component_id=component_id,
+                            display_name=display_name,
+                            component_attribute_class_id=component_attribute_class_id,
+                            hw_uid=hw_uid)
+
+    @classmethod
+    def check_initialization_consistency(cls, attributes):
+        SensorComponent.check_uniqueness_of_primary_key(attributes)
+        SensorComponent.check_existence_of_certain_attributes(attributes)
+
+    @property
+    def cac(self) -> TempSensorCac:
+        if self.component_attribute_class_id not in TempSensorCac.by_id.keys():
+            raise DataClassLoadingError(f"TempSensorCacId {self.component_attribute_class_id} not loaded yet")
+        return TempSensorCac.by_id[self.component_attribute_class_id]

--- a/gw_spaceheat/docs/learning/pi_setup.md
+++ b/gw_spaceheat/docs/learning/pi_setup.md
@@ -73,3 +73,16 @@ mosquitto_pub -u MQTT_USERNAME -P MQTT_PW -t 'test' -m 'hi'
 
 (see settings.py for username and .env for password)
 
+# 1-wire
+Followed these instructions (https://learn.adafruit.com/adafruits-raspberry-pi-lesson-11-ds18b20-temperature-sensing?view=all)
+
+sudo raspi-config, 5) Interface Options P7) 1-Wire, Select yes
+sudo reboot
+
+lsmod | grep -i w1_
+
+look for 
+w1_therm   
+w1_gpio
+wire
+

--- a/gw_spaceheat/drivers/boolean_actuator/boolean_actuator_driver.py
+++ b/gw_spaceheat/drivers/boolean_actuator/boolean_actuator_driver.py
@@ -4,7 +4,7 @@ from data_classes.components.boolean_actuator_component import \
     BooleanActuatorComponent
 
 
-class BooleanActuator(ABC):
+class BooleanActuatorDriver(ABC):
     def __init__(self, component: BooleanActuatorComponent):
         self.component = component
 

--- a/gw_spaceheat/drivers/boolean_actuator/gridworks_simbool30amprelay__boolean_actuator_driver.py
+++ b/gw_spaceheat/drivers/boolean_actuator/gridworks_simbool30amprelay__boolean_actuator_driver.py
@@ -1,12 +1,12 @@
 from data_classes.components.boolean_actuator_component import \
     BooleanActuatorComponent
-from drivers.boolean_actuator.boolean_actuator_base import BooleanActuator
+from drivers.boolean_actuator.boolean_actuator_driver import BooleanActuatorDriver
 
 
-class Gridworks__SimBool30AmpRelay__BooleanActuator(BooleanActuator):
+class GridworksSimBool30AmpRelay_BooleanActuatorDriver(BooleanActuatorDriver):
 
     def __init__(self,  component: BooleanActuatorComponent):
-        super(Gridworks__SimBool30AmpRelay__BooleanActuator,self).__init__(component=component)
+        super(GridworksSimBool30AmpRelay_BooleanActuatorDriver,self).__init__(component=component)
 
     def turn_on(self):
         raise NotImplementedError(f"Need to send TURN ON rabbit msg to simulated element via gpio {self.component.gpio} ")

--- a/gw_spaceheat/drivers/boolean_actuator/ncd__pr814spst__boolean_actuator_driver.py
+++ b/gw_spaceheat/drivers/boolean_actuator/ncd__pr814spst__boolean_actuator_driver.py
@@ -2,14 +2,14 @@ import smbus2 as smbus
 from data_classes.components.boolean_actuator_component import \
     BooleanActuatorComponent
 from drivers.base.mcp23008 import mcp23008
-from drivers.boolean_actuator.boolean_actuator_base import BooleanActuator
+from drivers.boolean_actuator.boolean_actuator_driver import BooleanActuatorDriver
 
 COMPONENT_ADDRESS = 0x20
 
-class Ncd__Pr8_14_Spst__BooleanActuator(BooleanActuator):
+class NcdPr814Spst_BooleanActuatorDriver(BooleanActuatorDriver):
 
     def __init__(self,  component: BooleanActuatorComponent):
-        super(Ncd__Pr8_14_Spst__BooleanActuator,self).__init__(component=component)
+        super( NcdPr814Spst_BooleanActuatorDriver,self).__init__(component=component)
         bus = smbus.SMBus(1)
         gpio_output_map =  {0,1,2,3}
         kwargs = {'address': COMPONENT_ADDRESS, 'gpio_output_map': gpio_output_map}

--- a/gw_spaceheat/drivers/temp_sensor/adafruit_642__temp_sensor_driver.py
+++ b/gw_spaceheat/drivers/temp_sensor/adafruit_642__temp_sensor_driver.py
@@ -1,0 +1,48 @@
+""" driver code for Adafruit 642 High Temp Waterproof DS18B20 Digital temp sensor """
+
+import time
+import os
+import platform
+
+import schema.property_format as property_format
+
+from data_classes.components.temp_sensor_component import TempSensorComponent
+from drivers.temp_sensor.temp_sensor_driver import TempSensorDriver
+
+BASE_DIR = '/sys/bus/w1/devices/'
+ONE_WIRE_FILE_START_ID = '28'
+
+
+class Adafruit642_TempSensorDriver(TempSensorDriver):
+
+    def __init__(self, component: TempSensorComponent):
+        super(Adafruit642_TempSensorDriver,self).__init__(component=component)
+        if component.cac.make_model != 'Adafruit__642':
+            raise Exception(f"Expected Adafruit__642, got {component.cac}")
+        property_format.check_is_64_bit_hex(component.hw_uid)
+
+    def read_temp_raw(self):
+        if platform.system() == 'Darwin':
+            raise Exception(f"Calling onewire from a mac! Check component ....")
+        all_driver_data_folders = list(filter(lambda x: x.startswith(ONE_WIRE_FILE_START_ID),[x[1] for x in os.walk(BASE_DIR)][0]))
+        candidate_driver_data_folders = list(filter(lambda x: x.endswith(self.component.hw_uid), all_driver_data_folders))
+        if len(candidate_driver_data_folders) != 1:
+            raise Exception(f"looking for unique folder ending in {self.component.hw_uid}. Found {candidate_driver_data_folders}")
+        device_folder = candidate_driver_data_folders[0]
+        device_file = device_folder + '/w1_slave'
+        f = open(device_file, 'r')
+        lines = f.readlines()
+        f.close()
+        return lines
+
+    def read_temp(self) -> int:
+        lines = self.read_temp_raw()
+        while lines[0].strip()[-3:] != 'YES':
+            time.sleep(0.2)
+            lines = self.read_temp_raw()
+        equals_pos = lines[1].find('t=')
+        if equals_pos != -1:
+            temp_string = lines[1][equals_pos+2:]
+            temp_c_times_1000 = int(temp_string) 
+        return temp_c_times_1000
+

--- a/gw_spaceheat/drivers/temp_sensor/adafruit_642__temp_sensor_driver.py
+++ b/gw_spaceheat/drivers/temp_sensor/adafruit_642__temp_sensor_driver.py
@@ -28,7 +28,7 @@ class Adafruit642_TempSensorDriver(TempSensorDriver):
         candidate_driver_data_folders = list(filter(lambda x: x.endswith(self.component.hw_uid), all_driver_data_folders))
         if len(candidate_driver_data_folders) != 1:
             raise Exception(f"looking for unique folder ending in {self.component.hw_uid}. Found {candidate_driver_data_folders}")
-        device_folder = candidate_driver_data_folders[0]
+        device_folder = BASE_DIR + candidate_driver_data_folders[0]
         device_file = device_folder + '/w1_slave'
         f = open(device_file, 'r')
         lines = f.readlines()

--- a/gw_spaceheat/drivers/temp_sensor/gridworks_water_temp_high_precision_temp_sensor_driver.py
+++ b/gw_spaceheat/drivers/temp_sensor/gridworks_water_temp_high_precision_temp_sensor_driver.py
@@ -1,0 +1,19 @@
+import random
+import time
+
+from data_classes.components.temp_sensor_component import TempSensorComponent
+from drivers.temp_sensor.temp_sensor_driver import TempSensorDriver
+
+
+class GridworksWaterTempSensorHighPrecision_TempSensorDriver(TempSensorDriver):
+
+    def __init__(self, component: TempSensorComponent):
+        super(GridworksWaterTempSensorHighPrecision_TempSensorDriver,self).__init__(component=component)
+        if component.cac.make_model != 'GridWorks__WaterTempHighPrecision':
+            raise Exception(f"Expected GridWorks__WaterTempHighPrecision, got {component.cac}")
+
+    def read_temp(self):
+        reading_time_ms = 879 + int(6* random.random())
+        temp_f_times_1000 = 67000 + int(500*random.random())
+        time.sleep(reading_time_ms/1000)
+        return temp_f_times_1000

--- a/gw_spaceheat/drivers/temp_sensor/temp_sensor_driver.py
+++ b/gw_spaceheat/drivers/temp_sensor/temp_sensor_driver.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+
+from data_classes.components.sensor_component import \
+    SensorComponent
+from data_classes.cacs.temp_sensor_cac import TempSensorCac
+
+
+class TempSensorDriver(ABC):
+    def __init__(self, component: SensorComponent):
+        if not isinstance(component.cac,TempSensorCac):
+            raise Exception(f"component {component} is not a TempSensor!!")
+        self.component = component
+
+    @abstractmethod
+    def read_temp(self):
+        raise NotImplementedError

--- a/gw_spaceheat/input_data/dev_house.json
+++ b/gw_spaceheat/input_data/dev_house.json
@@ -126,7 +126,8 @@
             "ShNodeRoleAlias": "Sensor",
             "DisplayName": "Top Water Temp sensor in tank",
             "ShNodeId": "3593a10a-4335-447a-b62e-e123788a134a",
-            "PrimaryComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce"
+            "PrimaryComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
+            "PythonActorName": "TankWaterTempSensor"
         },
         {
             "Alias": "a.tank.temp1",
@@ -202,49 +203,53 @@
             "ComponentId": "e758eecd-6439-4e1d-9f66-534f6fc14859",
             "DisplayName": "relay for main circulator pump",
             "ComponentAttributeClassId": "69f101fc-22e4-4caa-8103-50b8aeb66028",
-            "Gpio": 0
+            "Gpio": 1
         }
     ],
-    "SensorComponents": [
-        {
-            "ComponentId": "863359e1-f30a-4090-90a6-fc93154494a1",
-            "DisplayName": "Outdoor Temperature Sensor",
-            "ComponentAttributeClassId": "cac0f096-b460-4dce-aabf-a81ccce23566"
-        },
+    "TempSensorComponents": [{
+        "ComponentId": "863359e1-f30a-4090-90a6-fc93154494a1",
+        "DisplayName": "Outdoor Temperature Sensor",
+        "ComponentAttributeClassId": "cac0f096-b460-4dce-aabf-a81ccce23566"
+    },
+    {
+        "ComponentId": "a16d7bb6-2606-4ad1-b6b4-be80b5d84a6e",
+        "DisplayName": "Temp sensor on pipe out of tank",
+        "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318"
+    },
+    {
+        "ComponentId": "efabaa6a-e331-491f-9dbb-a3dee0029531",
+        "DisplayName": "Temp sensor on pipe into tank",
+        "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318"
+    },
+    {
+        "ComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
+        "DisplayName": "Top water temp sensor in tank",
+        "ComponentAttributeClassId": "8a1a1538-ed2d-4829-9c03-f9be1c9f9c83",
+        "HwUid": "1023abcd"
+    },
+    {
+        "ComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
+        "DisplayName": "Bottom water temp sensor in tank",
+        "ComponentAttributeClassId": "8a1a1538-ed2d-4829-9c03-f9be1c9f9c83"
+    },
+    {
+        "ComponentId": "23a09f17-741a-49b2-afbc-04f17f476594",
+        "DisplayName": "First garage temp sensor",
+        "ComponentAttributeClassId": "5450e92e-8c11-4383-b9b1-c8f412d83608"
+    }
+    ],
+    "ElectricMeterComponents": [
         {
             "ComponentId": "2bfd0036-0b0e-4732-8790-bc7d0536a85e",
             "DisplayName": "Main Power meter for Little orange house garage space heat",
             "ComponentAttributeClassId": "28897ac1-ea42-4633-96d3-196f63f5a951"
-        },
+        }
+    ],
+    "PipeFlowSensorComponents": [
         {
             "ComponentId": "dd5ac673-91a8-40e2-a233-b67479cec709",
             "DisplayName": "Flow meter on pipe out of tank",
             "ComponentAttributeClassId": "14e7105a-e797-485a-a304-328ecc85cd98"
-        },
-        {
-            "ComponentId": "a16d7bb6-2606-4ad1-b6b4-be80b5d84a6e",
-            "DisplayName": "Temp sensor on pipe out of tank",
-            "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318"
-        },
-        {
-            "ComponentId": "efabaa6a-e331-491f-9dbb-a3dee0029531",
-            "DisplayName": "Temp sensor on pipe into tank",
-            "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318"
-        },
-        {
-            "ComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
-            "DisplayName": "Top water temp sensor in tank",
-            "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8"
-        },
-        {
-            "ComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
-            "DisplayName": "Bottom water temp sensor in tank",
-            "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8"
-        },
-        {
-            "ComponentId": "23a09f17-741a-49b2-afbc-04f17f476594",
-            "DisplayName": "First garage temp sensor",
-            "ComponentAttributeClassId": "5450e92e-8c11-4383-b9b1-c8f412d83608"
         }
     ],
     "OtherComponents": [
@@ -292,22 +297,31 @@
             "MakeModel": "GridWorks__SimBool30AmpRelay"
         }
     ],
-    "SensorCacs":[
-        {
-            "ComponentAttributeClassId": "28897ac1-ea42-4633-96d3-196f63f5a951",
-            "SensorTypeValue": "ElectricPowerMeter"
-        },
+    "PipeFlowSensorCacs":[
         {
             "ComponentAttributeClassId": "14e7105a-e797-485a-a304-328ecc85cd98",
             "SensorTypeValue": "WaterFlowMeter"
+        }
+    ],
+    "ElectricMeterCacs": [
+        {
+            "ComponentAttributeClassId": "28897ac1-ea42-4633-96d3-196f63f5a951",
+            "SensorTypeValue": "ElectricPowerMeter"
+        }
+    ],
+    "TempSensorCacs": [
+        {
+            "ComponentAttributeClassId": "8a1a1538-ed2d-4829-9c03-f9be1c9f9c83",
+            "MakeModel": "GridWorks__WaterTempHighPrecision",
+            "DisplayName": "Simulated GridWorks high precision water temp sensor",
+            "SensorTypeValue": "WaterStoreTempSensor",
+            "CommsMethod": "SassyMQ",
+            "PrecisionExponent": 3,
+            "TempUnit": "F"
         },
         {
             "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318",
             "SensorTypeValue": "PipeClampWaterTempSensor"
-        },
-        {
-            "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
-            "SensorTypeValue": "WaterStoreTempSensor"
         },
         {
             "ComponentAttributeClassId": "5450e92e-8c11-4383-b9b1-c8f412d83608",

--- a/gw_spaceheat/input_data/dev_house.json
+++ b/gw_spaceheat/input_data/dev_house.json
@@ -124,7 +124,7 @@
         {
             "Alias": "a.tank.temp0",
             "ShNodeRoleAlias": "Sensor",
-            "DisplayName": "Top Water Temp sensor in tank",
+            "DisplayName": "Tank temp sensor temp0 (on top)",
             "ShNodeId": "3593a10a-4335-447a-b62e-e123788a134a",
             "PrimaryComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
             "PythonActorName": "TankWaterTempSensor"
@@ -132,9 +132,34 @@
         {
             "Alias": "a.tank.temp1",
             "ShNodeRoleAlias": "Sensor",
-            "DisplayName": "Bottom Water Temp sensor in tank",
+            "DisplayName": "Tank temp sensor temp1 (second from top)",
             "ShNodeId": "0df93059-f155-4c4f-a43c-0265a28f21fb",
-            "PrimaryComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e" 
+            "PrimaryComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
+            "PythonActorName": "TankWaterTempSensor"
+        },
+        {
+            "Alias": "a.tank.temp2",
+            "ShNodeRoleAlias": "Sensor",
+            "DisplayName": "Tank temp sensor temp2 (third from top)",
+            "ShNodeId": "17f84be9-6237-4331-91f8-17452eba0345",
+            "PrimaryComponentId": "5453b43b-7940-463c-ae6e-5cfe86ecbd3d",
+            "PythonActorName": "TankWaterTempSensor"
+        },
+        {
+            "Alias": "a.tank.temp3",
+            "ShNodeRoleAlias": "Sensor",
+            "DisplayName": "Tank temp sensor temp3 (fourth from top)",
+            "ShNodeId": "296c9002-5771-4e11-969c-48a6db905b83",
+            "PrimaryComponentId": "17110718-b102-4c3b-ae62-5331aec9eed3",
+            "PythonActorName": "TankWaterTempSensor"
+        },
+        {
+            "Alias": "a.tank.temp4",
+            "ShNodeRoleAlias": "Sensor",
+            "DisplayName": "Tank temp sensor temp4 (fifth from top)",
+            "ShNodeId": "0680a809-d56f-42d8-8d98-e7c23e94d311",
+            "PrimaryComponentId": "bc2b731d-2b68-4cb8-9c27-8dd84dd2ea82",
+            "PythonActorName": "TankWaterTempSensor"
         },
         {
             "Alias": "a.tank.out.allradiators.garage.temp1",
@@ -223,19 +248,39 @@
     },
     {
         "ComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
-        "DisplayName": "Top water temp sensor in tank",
+        "DisplayName": "Component for a.tank.temp0 (on top)",
         "ComponentAttributeClassId": "8a1a1538-ed2d-4829-9c03-f9be1c9f9c83",
         "HwUid": "1023abcd"
     },
     {
         "ComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
-        "DisplayName": "Bottom water temp sensor in tank",
-        "ComponentAttributeClassId": "8a1a1538-ed2d-4829-9c03-f9be1c9f9c83"
+        "DisplayName": "Component for a.tank.temp1 (second from top)",
+        "ComponentAttributeClassId": "8a1a1538-ed2d-4829-9c03-f9be1c9f9c83",
+        "HWUid": "10032fff"
+    },
+    {
+        "ComponentId": "5453b43b-7940-463c-ae6e-5cfe86ecbd3d",
+        "DisplayName": "Component for a.tank.temp2 (third from top)",
+        "ComponentAttributeClassId": "8a1a1538-ed2d-4829-9c03-f9be1c9f9c83",
+        "HwUid": "1004aaaa"
+    },
+    {
+        "ComponentId": "17110718-b102-4c3b-ae62-5331aec9eed3",
+        "DisplayName": "Component for a.tank.temp3 (fourth from top)",
+        "ComponentAttributeClassId": "8a1a1538-ed2d-4829-9c03-f9be1c9f9c83",
+        "HwUid": "100f2128"
+    },
+    {
+        "ComponentId": "bc2b731d-2b68-4cb8-9c27-8dd84dd2ea82",
+        "DisplayName": "Component for a.tank.temp4 (fifth from top)",
+        "ComponentAttributeClassId": "8a1a1538-ed2d-4829-9c03-f9be1c9f9c83",
+        "HwUid": "1004bbbb"
     },
     {
         "ComponentId": "23a09f17-741a-49b2-afbc-04f17f476594",
         "DisplayName": "First garage temp sensor",
-        "ComponentAttributeClassId": "5450e92e-8c11-4383-b9b1-c8f412d83608"
+        "ComponentAttributeClassId": "5450e92e-8c11-4383-b9b1-c8f412d83608",
+        "HwUid": "1004aaaa"
     }
     ],
     "ElectricMeterComponents": [

--- a/gw_spaceheat/input_data/pi_dev_house.json
+++ b/gw_spaceheat/input_data/pi_dev_house.json
@@ -124,7 +124,7 @@
         {
             "Alias": "a.tank.temp0",
             "ShNodeRoleAlias": "Sensor",
-            "DisplayName": "Top Water Temp sensor in tank",
+            "DisplayName": "Tank temp sensor #0 (on top)",
             "ShNodeId": "3593a10a-4335-447a-b62e-e123788a134a",
             "PrimaryComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
             "PythonActorName": "TankWaterTempSensor"
@@ -132,7 +132,7 @@
         {
             "Alias": "a.tank.temp1",
             "ShNodeRoleAlias": "Sensor",
-            "DisplayName": "Bottom Water Temp sensor in tank",
+            "DisplayName": "Tank temp sensor #1 (second from top)",
             "ShNodeId": "0df93059-f155-4c4f-a43c-0265a28f21fb",
             "PrimaryComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e" 
         },
@@ -223,14 +223,15 @@
     },
     {
         "ComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
-        "DisplayName": "Top water temp sensor in tank",
+        "DisplayName": "Tank temp sensor component #0 (on top)",
         "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
         "HwUid": "0003debb"
     },
     {
         "ComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
-        "DisplayName": "Bottom water temp sensor in tank",
-        "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8"
+        "DisplayName": "Tank temp sensor component #1 (second from top)",
+        "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
+        "HwUid": "0003c2c4"
     },
     {
         "ComponentId": "23a09f17-741a-49b2-afbc-04f17f476594",

--- a/gw_spaceheat/input_data/pi_dev_house.json
+++ b/gw_spaceheat/input_data/pi_dev_house.json
@@ -126,6 +126,7 @@
             "ShNodeRoleAlias": "Sensor",
             "DisplayName": "Top Water Temp sensor in tank",
             "ShNodeId": "3593a10a-4335-447a-b62e-e123788a134a",
+            "PrimaryComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
             "PythonActorName": "TankWaterTempSensor"
         },
         {

--- a/gw_spaceheat/input_data/pi_dev_house.json
+++ b/gw_spaceheat/input_data/pi_dev_house.json
@@ -126,7 +126,7 @@
             "ShNodeRoleAlias": "Sensor",
             "DisplayName": "Top Water Temp sensor in tank",
             "ShNodeId": "3593a10a-4335-447a-b62e-e123788a134a",
-            "PrimaryComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce"
+            "PythonActorName": "TankWaterTempSensor"
         },
         {
             "Alias": "a.tank.temp1",
@@ -205,46 +205,50 @@
             "Gpio": 3
         }
     ],
-    "SensorComponents": [
-        {
-            "ComponentId": "863359e1-f30a-4090-90a6-fc93154494a1",
-            "DisplayName": "Outdoor Temperature Sensor",
-            "ComponentAttributeClassId": "cac0f096-b460-4dce-aabf-a81ccce23566"
-        },
+    "TempSensorComponents": [{
+        "ComponentId": "863359e1-f30a-4090-90a6-fc93154494a1",
+        "DisplayName": "Outdoor Temperature Sensor",
+        "ComponentAttributeClassId": "cac0f096-b460-4dce-aabf-a81ccce23566"
+    },
+    {
+        "ComponentId": "a16d7bb6-2606-4ad1-b6b4-be80b5d84a6e",
+        "DisplayName": "Temp sensor on pipe out of tank",
+        "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318"
+    },
+    {
+        "ComponentId": "efabaa6a-e331-491f-9dbb-a3dee0029531",
+        "DisplayName": "Temp sensor on pipe into tank",
+        "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318"
+    },
+    {
+        "ComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
+        "DisplayName": "Top water temp sensor in tank",
+        "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
+        "HwUid": "0003debb"
+    },
+    {
+        "ComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
+        "DisplayName": "Bottom water temp sensor in tank",
+        "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8"
+    },
+    {
+        "ComponentId": "23a09f17-741a-49b2-afbc-04f17f476594",
+        "DisplayName": "First garage temp sensor",
+        "ComponentAttributeClassId": "5450e92e-8c11-4383-b9b1-c8f412d83608"
+    }
+    ],
+    "ElectricMeterComponents": [
         {
             "ComponentId": "2bfd0036-0b0e-4732-8790-bc7d0536a85e",
             "DisplayName": "Main Power meter for Little orange house garage space heat",
             "ComponentAttributeClassId": "28897ac1-ea42-4633-96d3-196f63f5a951"
-        },
+        }
+    ],
+    "PipeFlowSensorComponents": [
         {
             "ComponentId": "dd5ac673-91a8-40e2-a233-b67479cec709",
             "DisplayName": "Flow meter on pipe out of tank",
             "ComponentAttributeClassId": "14e7105a-e797-485a-a304-328ecc85cd98"
-        },
-        {
-            "ComponentId": "a16d7bb6-2606-4ad1-b6b4-be80b5d84a6e",
-            "DisplayName": "Temp sensor on pipe out of tank",
-            "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318"
-        },
-        {
-            "ComponentId": "efabaa6a-e331-491f-9dbb-a3dee0029531",
-            "DisplayName": "Temp sensor on pipe into tank",
-            "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318"
-        },
-        {
-            "ComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
-            "DisplayName": "Top water temp sensor in tank",
-            "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8"
-        },
-        {
-            "ComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
-            "DisplayName": "Bottom water temp sensor in tank",
-            "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8"
-        },
-        {
-            "ComponentId": "23a09f17-741a-49b2-afbc-04f17f476594",
-            "DisplayName": "First garage temp sensor",
-            "ComponentAttributeClassId": "5450e92e-8c11-4383-b9b1-c8f412d83608"
         }
     ],
     "OtherComponents": [
@@ -292,22 +296,28 @@
             "MakeModel": "NCD__PR8-14-SPST"
         }
     ],
-    "SensorCacs":[
-        {
-            "ComponentAttributeClassId": "28897ac1-ea42-4633-96d3-196f63f5a951",
-            "SensorTypeValue": "ElectricPowerMeter"
-        },
+    "PipeFlowSensorCacs":[
+        
         {
             "ComponentAttributeClassId": "14e7105a-e797-485a-a304-328ecc85cd98",
             "SensorTypeValue": "WaterFlowMeter"
-        },
+        }
+    ],
+    "ElectricMeterCacs": [
         {
-            "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318",
-            "SensorTypeValue": "PipeClampWaterTempSensor"
-        },
+            "ComponentAttributeClassId": "28897ac1-ea42-4633-96d3-196f63f5a951",
+            "SensorTypeValue": "ElectricPowerMeter"
+        }
+    ],
+    "TempSensorCacs": [
         {
             "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
-            "SensorTypeValue": "WaterStoreTempSensor"
+            "MakeModel": "Adafruit__642",
+            "DisplayName": "Adafruit High Temp Waterproof DS18B20 Digital Temp Sensor",
+            "CommsMethod": "OneWire",
+            "SensorTypeValue": "WaterStoreTempSensor",
+            "PrecisionExponent": 3,
+            "TempUnit": "C"
         },
         {
             "ComponentAttributeClassId": "5450e92e-8c11-4383-b9b1-c8f412d83608",
@@ -316,6 +326,10 @@
         {
             "ComponentAttributeClassId": "cac0f096-b460-4dce-aabf-a81ccce23566",
             "SensorTypeValue": "OutdoorAirTempSensor"
+        },
+        {
+            "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318",
+            "SensorTypeValue": "PipeClampWaterTempSensor"
         }
     ],
     "OtherCacs": [

--- a/gw_spaceheat/input_data/pi_dev_house.json
+++ b/gw_spaceheat/input_data/pi_dev_house.json
@@ -134,7 +134,8 @@
             "ShNodeRoleAlias": "Sensor",
             "DisplayName": "Tank temp sensor #1 (second from top)",
             "ShNodeId": "0df93059-f155-4c4f-a43c-0265a28f21fb",
-            "PrimaryComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e" 
+            "PrimaryComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
+            "PythonActorName": "TankWaterTempSensor"
         },
         {
             "Alias": "a.tank.out.allradiators.garage.temp1",

--- a/gw_spaceheat/input_data/pi_dev_house.json
+++ b/gw_spaceheat/input_data/pi_dev_house.json
@@ -138,6 +138,30 @@
             "PythonActorName": "TankWaterTempSensor"
         },
         {
+            "Alias": "a.tank.temp2",
+            "ShNodeRoleAlias": "Sensor",
+            "DisplayName": "Tank temp sensor #2 (third from top)",
+            "ShNodeId": "17f84be9-6237-4331-91f8-17452eba0345",
+            "PrimaryComponentId": "fef75047-6416-46d1-bd08-1c10beefa69d",
+            "PythonActorName": "TankWaterTempSensor"
+        },
+        {
+            "Alias": "a.tank.temp3",
+            "ShNodeRoleAlias": "Sensor",
+            "DisplayName": "Tank temp sensor #3 (fourth from top)",
+            "ShNodeId": "296c9002-5771-4e11-969c-48a6db905b83",
+            "PrimaryComponentId": "14330fc6-c26e-4b74-9000-87e10da65828",
+            "PythonActorName": "TankWaterTempSensor"
+        },
+        {
+            "Alias": "a.tank.temp4",
+            "ShNodeRoleAlias": "Sensor",
+            "DisplayName": "Tank temp sensor #4 (fifth from top)",
+            "ShNodeId": "0680a809-d56f-42d8-8d98-e7c23e94d311",
+            "PrimaryComponentId": "2ca9e65a-5e85-4eaa-811b-901e940f8d09",
+            "PythonActorName": "TankWaterTempSensor"
+        },
+        {
             "Alias": "a.tank.out.allradiators.garage.temp1",
             "ShNodeRoleAlias": "Sensor",
             "DisplayName": "First Garage Temp sensor",
@@ -224,15 +248,33 @@
     },
     {
         "ComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
-        "DisplayName": "Tank temp sensor component #0 (on top)",
+        "DisplayName": "Component for a.tank.temp0 (on top)",
         "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
         "HwUid": "0003debb"
     },
     {
         "ComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
-        "DisplayName": "Tank temp sensor component #1 (second from top)",
+        "DisplayName": "Component for a.tank.temp1 (second from top)",
         "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
         "HwUid": "0003c2c4"
+    },
+    {
+        "ComponentId": "fef75047-6416-46d1-bd08-1c10beefa69d",
+        "DisplayName": "Component for a.tank.temp2 (third from top)",
+        "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
+        "HwUid": "00034a8f"
+    },
+    {
+        "ComponentId": "14330fc6-c26e-4b74-9000-87e10da65828",
+        "DisplayName": "Component for a.tank.temp3 (fourth from top)",
+        "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
+        "HwUid": "00039d4b"
+    },
+    {
+        "ComponentId": "2ca9e65a-5e85-4eaa-811b-901e940f8d09",
+        "DisplayName": "Component for a.tank.temp4 (fourth from top)",
+        "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
+        "HwUid": "00033ffe"
     },
     {
         "ComponentId": "23a09f17-741a-49b2-afbc-04f17f476594",

--- a/gw_spaceheat/load_house.py
+++ b/gw_spaceheat/load_house.py
@@ -2,17 +2,23 @@ import json
 import os
 
 from data_classes.cacs.boolean_actuator_cac import BooleanActuatorCac
-from data_classes.component_attribute_class import ComponentAttributeClass
 from data_classes.cacs.electric_heater_cac import ElectricHeaterCac
-from data_classes.cacs.sensor_cac import SensorCac
+from data_classes.cacs.electric_meter_cac import ElectricMeterCac
+from data_classes.cacs.pipe_flow_sensor_cac import PipeFlowSensorCac
+from data_classes.cacs.temp_sensor_cac import TempSensorCac
+from data_classes.component import Component
+from data_classes.component_attribute_class import ComponentAttributeClass
 from data_classes.components.boolean_actuator_component import \
     BooleanActuatorComponent
-from data_classes.component import Component
 from data_classes.components.electric_heater_component import \
     ElectricHeaterComponent
-from data_classes.components.sensor_component import SensorComponent
+from data_classes.components.electric_meter_component import \
+    ElectricMeterComponent
+from data_classes.components.pipe_flow_sensor_component import \
+    PipeFlowSensorComponent
+from data_classes.components.temp_sensor_component import TempSensorComponent
 from data_classes.sh_node import ShNode
-from data_classes.thermal_edge import ThermalEdge
+
 from helpers import camel_to_snake
 
 HOUSE_JSON_FILE = 'input_data/dev_house.json'
@@ -25,9 +31,15 @@ def load_cacs(input_data):
     for camel in input_data['ElectricHeaterCacs']:
         snake_dict = {camel_to_snake(k): v for k, v in camel.items()}
         component = ElectricHeaterCac(**snake_dict)
-    for camel in input_data['SensorCacs']:
+    for camel in input_data['ElectricMeterCacs']:
         snake_dict = {camel_to_snake(k): v for k, v in camel.items()}
-        component = SensorCac(**snake_dict) 
+        component = ElectricMeterCac(**snake_dict)
+    for camel in input_data['TempSensorCacs']:
+        snake_dict = {camel_to_snake(k): v for k, v in camel.items()}
+        component = TempSensorCac(**snake_dict) 
+    for camel in input_data['PipeFlowSensorCacs']:
+        snake_dict = {camel_to_snake(k): v for k, v in camel.items()}
+        component = PipeFlowSensorCac(**snake_dict) 
     for camel in input_data['OtherCacs']:
         snake_dict = {camel_to_snake(k): v for k, v in camel.items()}
         component = ComponentAttributeClass(**snake_dict)      
@@ -40,9 +52,15 @@ def load_components(input_data):
     for camel in input_data['ElectricHeaterComponents']:
         snake_dict = {camel_to_snake(k): v for k, v in camel.items()}
         component = ElectricHeaterComponent(**snake_dict)
-    for camel in input_data['SensorComponents']:
+    for camel in input_data['ElectricMeterComponents']:
         snake_dict = {camel_to_snake(k): v for k, v in camel.items()}
-        component = SensorComponent(**snake_dict)
+        component = ElectricMeterComponent(**snake_dict)
+    for camel in input_data['TempSensorComponents']:
+        snake_dict = {camel_to_snake(k): v for k, v in camel.items()}
+        component = TempSensorComponent(**snake_dict)
+    for camel in input_data['PipeFlowSensorComponents']:
+        snake_dict = {camel_to_snake(k): v for k, v in camel.items()}
+        component = PipeFlowSensorComponent(**snake_dict)
     for camel in input_data['OtherComponents']:
         snake_dict = {camel_to_snake(k): v for k, v in camel.items()}
         component = Component(**snake_dict)

--- a/gw_spaceheat/schema/gt/gt_telemetry/gt_telemetry_1_0_1.py
+++ b/gw_spaceheat/schema/gt/gt_telemetry/gt_telemetry_1_0_1.py
@@ -1,13 +1,13 @@
-"""gt.telemetry.100 type"""
+"""gt.telemetry.101 type"""
 from typing import List, Tuple, Optional
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0_base import GtTelemetry100Base
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1_base import GtTelemetry101Base
 
 
-class GtTelemetry100(GtTelemetry100Base):
+class GtTelemetry101(GtTelemetry101Base):
     def is_valid(self) -> Tuple[bool, Optional[List[str]]]:
         is_valid, errors = self.passes_derived_validations()
         if len(errors) > 0:
-            errors.insert(0, 'Errors making gt.telemetry.100 type.')
+            errors.insert(0, 'Errors making gt.telemetry.101 type.')
         return is_valid, errors
 
     # hand-code schema axiom validations below

--- a/gw_spaceheat/schema/gt/gt_telemetry/gt_telemetry_1_0_1_base.py
+++ b/gw_spaceheat/schema/gt/gt_telemetry/gt_telemetry_1_0_1_base.py
@@ -1,4 +1,4 @@
-"""Base for gt.telemetry.100"""
+"""Base for gt.telemetry.101"""
 from typing import List, Tuple, Optional, NamedTuple
 import enum
 
@@ -7,13 +7,14 @@ from schema.property_format import is_reasonable_unix_time_ms
 
 class TelemetryName(enum.Enum):
     WATER_FLOW_GPM_TIMES_100 = "WaterFlowGpmTimes100"
+    WATER_TEMP_F_TIMES_1000 = "WaterTempFTimes1000"
+    WATER_TEMP_C_TIMES_1000 = "WaterTempCTimes1000"
 
-
-class GtTelemetry100Base(NamedTuple):
+class GtTelemetry101Base(NamedTuple):
     Name: str     #
     Value: int     #
     ScadaReadTimeUnixMs: int     #
-    MpAlias: str = 'gt.telemetry.100'
+    MpAlias: str = 'gt.telemetry.101'
 
     def asdict(self):
         d = self._asdict()
@@ -29,9 +30,9 @@ class GtTelemetry100Base(NamedTuple):
     def passes_derived_validations(self) -> Tuple[bool, Optional[List[str]]]:
         is_valid = True
         errors = []
-        if self.MpAlias != 'gt.telemetry.100':
+        if self.MpAlias != 'gt.telemetry.101':
             is_valid = False
-            errors.append(f"Payload requires MpAlias of gt.telemetry.100, not {self.MpAlias}.")
+            errors.append(f"Payload requires MpAlias of gt.telemetry.101, not {self.MpAlias}.")
         if not isinstance(self.Name, str):
             is_valid = False
             errors.append(f"Name {self.Name} must have type str.")

--- a/gw_spaceheat/schema/gt/gt_telemetry/gt_telemetry_1_0_1_maker.py
+++ b/gw_spaceheat/schema/gt/gt_telemetry/gt_telemetry_1_0_1_maker.py
@@ -1,19 +1,19 @@
-"""Makes gt.telemetry.100 type"""
+"""Makes gt.telemetry.101 type"""
 
 from typing import List, Dict, Tuple, Optional, Any
 
 from schema.errors import MpSchemaError
-from schema.gt.gt_telemetry.gt_telemetry_1_0_0 import GtTelemetry100
+from schema.gt.gt_telemetry.gt_telemetry_1_0_1 import GtTelemetry101
 
 
-class GtTelemetry100_Maker():
-    mp_alias = 'gt.telemetry.100'
+class GtTelemetry101_Maker():
+    mp_alias = 'gt.telemetry.101'
     
     @classmethod
-    def camel_dict_to_type(cls, d:dict) -> GtTelemetry100:
+    def camel_dict_to_type(cls, d:dict) -> GtTelemetry101:
         if 'MpAlias' not in d.keys():
-            d['MpAlias'] = 'gt.telemetry.100'
-        p = GtTelemetry100(Name=d["Name"],
+            d['MpAlias'] = 'gt.telemetry.101'
+        p = GtTelemetry101(Name=d["Name"],
                         Value=d["Value"],
                         ScadaReadTimeUnixMs=d["ScadaReadTimeUnixMs"])
         is_valid, errors = p.is_valid()
@@ -34,7 +34,7 @@ class GtTelemetry100_Maker():
                 value,
                 scada_read_time_unix_ms):
 
-        t = GtTelemetry100(Name=name,
+        t = GtTelemetry101(Name=name,
                     Value=value,
                     ScadaReadTimeUnixMs=scada_read_time_unix_ms)
 

--- a/gw_spaceheat/schema/property_format.py
+++ b/gw_spaceheat/schema/property_format.py
@@ -1,6 +1,13 @@
 import pendulum
 import struct
+import string
 
+def check_is_64_bit_hex(candidate):
+    if len(candidate) != 8:
+        raise Exception(f"Wrong number of bits for 64 bit hex! {candidate}")
+    if not all(c in string.hexdigits for c in candidate):
+        raise Exception(f"All digits must be hex! {candidate}")
+    return True
 
 def is_recognized_component_manufacturer(candidate):
     #TODO: add

--- a/gw_spaceheat/try_temp_sensor.py
+++ b/gw_spaceheat/try_temp_sensor.py
@@ -1,0 +1,14 @@
+import platform
+from data_classes.sh_node import ShNode
+from actors.strategy_switcher import main as strategy_switcher
+import load_house
+
+if platform.platform() == 'Linux-4.19.118-v7l+-armv7l-with-glibc2.28':
+    load_house.load_all(house_json_file='input_data/pi_dev_house.json')
+else:
+    load_house.load_all(house_json_file='input_data/dev_house.json')
+
+node = ShNode.by_alias["a.tank.temp0"]
+
+(actor_function, keys) = strategy_switcher(node.python_actor_name)
+sensor = actor_function(node)


### PR DESCRIPTION
TankWaterTempSensor actor now reads from an Adafruit High TempWaterproof DS18B20 temp sensor using 1-wire.![Adafruit High Temp Waterproof DS18B20 1-wire temp sensor](https://user-images.githubusercontent.com/20042809/170687872-1e153deb-742d-4b6e-b7b3-7039515f933e.png) New component attribute class with make_model Adafruit__642, with a driver in `drivers/temp_sensor/adafruit_642__temp_sensor_driver.py`

Also implemented simulated water temp sensor for local testing (make_model Gridworks__WaterTempHighPrecisionTempSensor).

You can test locally by running `try_temp_sensor.py`
 
At present the Adafruit sensor just reads as fast as it can -which appears to be about every 880 ms - and publishes to topic `a.tank.temp0/gt.telemetry.101`.
(`a.tank.temp0` is the alias for the sensor ShNode, and `gt.telemetry.101` is the alias of the schema for the message.)

Next week George and I will wire up 5 of these sensors and drop them into the Axeman watertank in order to start experimenting with water stratification.

Each sensor has its own unique serial number (64 bit hex),and they can all share the same data line. On the Pi, the data for each sensor is put in a file identified by its serial number. That's nice.