### PR TITLE
Calibrate temp sensors

### DIFF
--- a/gw_spaceheat/actors/primary_scada/primary_scada.py
+++ b/gw_spaceheat/actors/primary_scada/primary_scada.py
@@ -1,4 +1,7 @@
 from typing import List, Dict
+import pendulum
+import csv
+import time
 from actors.primary_scada.primary_scada_base import PrimaryScadaBase
 from data_classes.sh_node import ShNode
 from data_classes.components.boolean_actuator_component import BooleanActuatorComponent 
@@ -17,7 +20,17 @@ class PrimaryScada(PrimaryScadaBase):
         self.total_power_w = 0
         self.driver: Dict[ShNode, BooleanActuatorDriver] = {}
         self.set_actuator_components()
-        
+        self.temp_readings: List = []
+        for i in range(5):
+            time.sleep(60)
+            self.screen_print('Done with minute {i}')
+        out = 'tmp.csv'
+        self.screen_print("writing output")
+        with open(out, 'w') as outfile:
+            write = csv.writer(outfile, delimiter=',')
+            for row in self.temp_readings:
+                write.writerow(row)
+                    
         
     def set_actuator_components(self):
         """
@@ -56,6 +69,13 @@ class PrimaryScada(PrimaryScadaBase):
     
     def gt_telemetry_100_received(self, payload: GtTelemetry101, from_node: ShNode):
         self.screen_print(f"Got {payload} from {from_node.alias}")
+        self.payload = payload
+        t_unix_s = int(payload.ScadaReadTimeUnixMs/1000)
+        t = pendulum.from_timestamp(t_unix_s)
+        ms = payload.ScadaReadTimeUnixMs % 1000
+        self.temp_readings.append([t.strftime("%Y-%m-%d %H:%M:%S"),t_unix_s, ms, from_node.alias, payload.Value])
+        
+
 
     @property
     def my_meter(self) ->ShNode:

--- a/gw_spaceheat/actors/primary_scada/primary_scada_base.py
+++ b/gw_spaceheat/actors/primary_scada/primary_scada_base.py
@@ -15,7 +15,11 @@ class PrimaryScadaBase(ActorBase):
     def subscriptions(self) -> List[Subscription]:
         return [Subscription(Topic=f'{self.my_meter.alias}/{GsPwr100_Maker.mp_alias}',Qos=QOS.AtMostOnce),
                 Subscription(Topic=f'a.tank.out.flowmeter1/{GtTelemetry101_Maker.mp_alias}',Qos=QOS.AtLeastOnce),
-                Subscription(Topic=f'a.tank.temp0/{GtTelemetry101_Maker.mp_alias}',Qos=QOS.AtLeastOnce)]
+                Subscription(Topic=f'a.tank.temp0/{GtTelemetry101_Maker.mp_alias}',Qos=QOS.AtLeastOnce),
+                Subscription(Topic=f'a.tank.temp1/{GtTelemetry101_Maker.mp_alias}',Qos=QOS.AtLeastOnce),
+                Subscription(Topic=f'a.tank.temp2/{GtTelemetry101_Maker.mp_alias}',Qos=QOS.AtLeastOnce),
+                Subscription(Topic=f'a.tank.temp3/{GtTelemetry101_Maker.mp_alias}',Qos=QOS.AtLeastOnce),
+                Subscription(Topic=f'a.tank.temp4/{GtTelemetry101_Maker.mp_alias}',Qos=QOS.AtLeastOnce )]
 
     def on_message(self, client, userdata, message):
         try:

--- a/gw_spaceheat/actors/sensor/tank_water_temp_sensor.py
+++ b/gw_spaceheat/actors/sensor/tank_water_temp_sensor.py
@@ -55,5 +55,5 @@ class TankWaterTempSensor(SensorBase):
     def main(self):
         while True:
             self.temp = self.driver.read_temp()
-            self.screen_print(f"Just read temp {self.temp/(10**self.cac.precision_exponent)} {self.cac.temp_unit}")
+            #self.screen_print(f"Just read temp {self.temp/(10**self.cac.precision_exponent)} {self.cac.temp_unit}")
             self.publish()

--- a/gw_spaceheat/input_data/dev_house.json
+++ b/gw_spaceheat/input_data/dev_house.json
@@ -255,7 +255,7 @@
         "ComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
         "DisplayName": "Component for a.tank.temp1 (second from top)",
         "ComponentAttributeClassId": "8a1a1538-ed2d-4829-9c03-f9be1c9f9c83",
-        "HWUid": "10032fff"
+        "HwUid": "10032fff"
     },
     {
         "ComponentId": "5453b43b-7940-463c-ae6e-5cfe86ecbd3d",

--- a/gw_spaceheat/input_data/dev_house.json
+++ b/gw_spaceheat/input_data/dev_house.json
@@ -298,11 +298,6 @@
     ],
     "OtherComponents": [
         {
-            "ComponentId": "a128bda4-3674-4d55-b2b4-61a39d5cf886",
-            "DisplayName": "Little Orange House Primary Scada",
-            "ComponentAttributeClassId": "2d83cf4a-cb4f-46e6-a0ce-a13659694c90"
-        },
-        {
             "ComponentId": "d4a27899-98a3-409f-8c6a-771d86d7937b",
             "DisplayName": "Little Orange house Axeman Tank",
             "ComponentAttributeClassId": "683c193a-bf83-4491-a294-c0e32865a407"

--- a/gw_spaceheat/input_data/dev_house.json
+++ b/gw_spaceheat/input_data/dev_house.json
@@ -20,7 +20,6 @@
             "ShNodeRoleAlias": "PrimaryScada",
             "DisplayName": "Little Orange House Main Scada",
             "ShNodeId": "259f9431-c6a1-4170-8766-04cbf65cff4a",
-            "PrimaryComponentId": "a128bda4-3674-4d55-b2b4-61a39d5cf886",
             "PythonActorName": "PrimaryScada"
         },
         {
@@ -378,9 +377,6 @@
         }
     ],
     "OtherCacs": [
-        {
-            "ComponentAttributeClassId": "2d83cf4a-cb4f-46e6-a0ce-a13659694c90"
-        },
         {
             "ComponentAttributeClassId": "683c193a-bf83-4491-a294-c0e32865a407"
         },

--- a/gw_spaceheat/input_data/pi_dev_house.json
+++ b/gw_spaceheat/input_data/pi_dev_house.json
@@ -297,11 +297,6 @@
     ],
     "OtherComponents": [
         {
-            "ComponentId": "a128bda4-3674-4d55-b2b4-61a39d5cf886",
-            "DisplayName": "Little Orange House Primary Scada",
-            "ComponentAttributeClassId": "2d83cf4a-cb4f-46e6-a0ce-a13659694c90"
-        },
-        {
             "ComponentId": "d4a27899-98a3-409f-8c6a-771d86d7937b",
             "DisplayName": "Little Orange house Axeman Tank",
             "ComponentAttributeClassId": "683c193a-bf83-4491-a294-c0e32865a407"
@@ -377,9 +372,6 @@
         }
     ],
     "OtherCacs": [
-        {
-            "ComponentAttributeClassId": "2d83cf4a-cb4f-46e6-a0ce-a13659694c90"
-        },
         {
             "ComponentAttributeClassId": "683c193a-bf83-4491-a294-c0e32865a407"
         },

--- a/gw_spaceheat/input_data/pi_dev_house.json
+++ b/gw_spaceheat/input_data/pi_dev_house.json
@@ -20,7 +20,6 @@
             "ShNodeRoleAlias": "PrimaryScada",
             "DisplayName": "Little Orange House Main Scada",
             "ShNodeId": "259f9431-c6a1-4170-8766-04cbf65cff4a",
-            "PrimaryComponentId": "a128bda4-3674-4d55-b2b4-61a39d5cf886",
             "PythonActorName": "PrimaryScada"
         },
         {
@@ -124,7 +123,7 @@
         {
             "Alias": "a.tank.temp0",
             "ShNodeRoleAlias": "Sensor",
-            "DisplayName": "Tank temp sensor #0 (on top)",
+            "DisplayName": "Tank temp sensor temp0 (on top)",
             "ShNodeId": "3593a10a-4335-447a-b62e-e123788a134a",
             "PrimaryComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
             "PythonActorName": "TankWaterTempSensor"
@@ -132,7 +131,7 @@
         {
             "Alias": "a.tank.temp1",
             "ShNodeRoleAlias": "Sensor",
-            "DisplayName": "Tank temp sensor #1 (second from top)",
+            "DisplayName": "Tank temp sensor temp1 (second from top)",
             "ShNodeId": "0df93059-f155-4c4f-a43c-0265a28f21fb",
             "PrimaryComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
             "PythonActorName": "TankWaterTempSensor"
@@ -140,7 +139,7 @@
         {
             "Alias": "a.tank.temp2",
             "ShNodeRoleAlias": "Sensor",
-            "DisplayName": "Tank temp sensor #2 (third from top)",
+            "DisplayName": "Tank temp sensor temp2 (third from top)",
             "ShNodeId": "17f84be9-6237-4331-91f8-17452eba0345",
             "PrimaryComponentId": "fef75047-6416-46d1-bd08-1c10beefa69d",
             "PythonActorName": "TankWaterTempSensor"
@@ -148,7 +147,7 @@
         {
             "Alias": "a.tank.temp3",
             "ShNodeRoleAlias": "Sensor",
-            "DisplayName": "Tank temp sensor #3 (fourth from top)",
+            "DisplayName": "Tank temp sensor temp3 (fourth from top)",
             "ShNodeId": "296c9002-5771-4e11-969c-48a6db905b83",
             "PrimaryComponentId": "14330fc6-c26e-4b74-9000-87e10da65828",
             "PythonActorName": "TankWaterTempSensor"
@@ -156,7 +155,7 @@
         {
             "Alias": "a.tank.temp4",
             "ShNodeRoleAlias": "Sensor",
-            "DisplayName": "Tank temp sensor #4 (fifth from top)",
+            "DisplayName": "Tank temp sensor temp4 (fifth from top)",
             "ShNodeId": "0680a809-d56f-42d8-8d98-e7c23e94d311",
             "PrimaryComponentId": "2ca9e65a-5e85-4eaa-811b-901e940f8d09",
             "PythonActorName": "TankWaterTempSensor"
@@ -272,7 +271,7 @@
     },
     {
         "ComponentId": "2ca9e65a-5e85-4eaa-811b-901e940f8d09",
-        "DisplayName": "Component for a.tank.temp4 (fourth from top)",
+        "DisplayName": "Component for a.tank.temp4 (fifth from top)",
         "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
         "HwUid": "00033ffe"
     },


### PR DESCRIPTION
This is a temporary adjustment to the scada code where it creates a csv with temperature readings from the 5 temp sensors. We plan to install these 5 temp sensors in the Axeman water tank this coming week and needed to get some data to calibrate the sensors before doing that.

What we discovered: there is indeed some variance both in steady-state readings and in how rapidly the sensors adjust. We are likely going to want to calibrate for both of these things before installing the sensors in the tank and using them to study water temperature stratification.