### PR TITLE
MQTT publish works for more than 20 messages

### DIFF
--- a/gw_spaceheat/README.md
+++ b/gw_spaceheat/README.md
@@ -39,10 +39,8 @@ Settings use a gitignored settings.py file. There is a template settings_templat
 
 
 ### Setting up MQTT
-The SCADA uses two mqtt brokers - a local broker on Pi itself for internal mqtt messages, and a broker outside the LAN for communicating with its AtomicTNode. 
-
-TODO: ADD GOOD INSTRUCTIONS FOR SETTING UP AND CONFIGURING LOCAL MOSQUITTO BROKER. Right now
-we are using a mosquitto broker that came configured already on an emonPi[https://shop.openenergymonitor.com/emonpi/].
+For development purposes, you can set up .env to include MQTT_PW = None and use the default value in settings_template.py (one of the 
+many free cloud brokers))
 
 ## Step 2: input data and running the code
 

--- a/gw_spaceheat/README.md
+++ b/gw_spaceheat/README.md
@@ -42,6 +42,7 @@ Settings use a gitignored settings.py file. There is a template settings_templat
 For development purposes, you can set up .env to include MQTT_PW = None and use the default value in settings_template.py (one of the 
 many free cloud brokers))
 
+KNOWN ISSUE: some brokers restrict client_id to 23 characters. Our pattern right now is to use the node alias plus '-pub' for the publish client. We'll need to change that pattern since some of our aliases will be longer than 23 characters.
 ## Step 2: input data and running the code
 
 Input data is in input_data folder. The `dev_house.json` is used for developing on a mac. The `pi_dev_house.json` is used for a pi that is connected to actual hardware and has its various drivers (like i2c) enabled.

--- a/gw_spaceheat/actors/actor_base.py
+++ b/gw_spaceheat/actors/actor_base.py
@@ -7,6 +7,7 @@ from actors.mqtt_utils import Subscription
 import settings
 import helpers
 
+LOGGING_ON = True
 class ActorBase(ABC):
 
     def __init__(self, node: ShNode):
@@ -15,14 +16,19 @@ class ActorBase(ABC):
         self.publish_client = mqtt.Client(f"{node.alias}-pub")
         self.publish_client.username_pw_set(username=settings.MQTT_USER_NAME, password=helpers.get_secret('MQTT_PW'))
         self.publish_client.connect(self.mqttBroker)
+        if LOGGING_ON:
+            self.publish_client.on_log = self.on_log
         self.consume_client = mqtt.Client(f"{node.alias}")
         self.consume_client.username_pw_set(username=settings.MQTT_USER_NAME, password=helpers.get_secret('MQTT_PW'))
         self.consume_client.connect(self.mqttBroker)
+        if LOGGING_ON:
+            self.consume_client.on_log = self.on_log
         self.consume_thread = threading.Thread(target=self.consume)
 
+    def on_log(self, client, userdata, level, buf):
+        self.screen_print(f"log: {buf}")
 
     def consume(self):
-        print('hi')
         self.consume_client.subscribe(list(map(lambda x: (f"{x.Topic}", x.Qos.value), self.subscriptions())))
         self.consume_client.on_message = self.on_message
         self.consume_client.loop_forever()

--- a/gw_spaceheat/actors/actor_base.py
+++ b/gw_spaceheat/actors/actor_base.py
@@ -16,6 +16,7 @@ class ActorBase(ABC):
         self.publish_client = mqtt.Client(f"{node.alias}-pub")
         self.publish_client.username_pw_set(username=settings.MQTT_USER_NAME, password=helpers.get_secret('MQTT_PW'))
         self.publish_client.connect(self.mqttBroker)
+        self.publish_client.loop_start()
         if LOGGING_ON:
             self.publish_client.on_log = self.on_log
         self.consume_client = mqtt.Client(f"{node.alias}")

--- a/gw_spaceheat/actors/actor_base.py
+++ b/gw_spaceheat/actors/actor_base.py
@@ -7,7 +7,7 @@ from actors.mqtt_utils import Subscription
 import settings
 import helpers
 
-LOGGING_ON = True
+LOGGING_ON = False
 class ActorBase(ABC):
 
     def __init__(self, node: ShNode):

--- a/gw_spaceheat/actors/power_meter/power_meter_base.py
+++ b/gw_spaceheat/actors/power_meter/power_meter_base.py
@@ -17,8 +17,8 @@ class PowerMeterBase(ActorBase):
 
     def publish_gs_pwr(self, payload: GsPwr100):
         topic = f'{self.node.alias}/{GsPwr100_Maker.mp_alias}'
+        self.screen_print("Trying to publish")
         self.publish_client.publish(topic=topic, 
                             payload=payload.asbinary(),
                             qos = QOS.AtMostOnce.value,
                             retain=False)
-        self.screen_print(f"Just published {payload} to topic {topic}")

--- a/gw_spaceheat/actors/primary_scada/primary_scada_base.py
+++ b/gw_spaceheat/actors/primary_scada/primary_scada_base.py
@@ -49,12 +49,13 @@ class PrimaryScadaBase(ActorBase):
 
     def publish_gs_pwr(self, payload: GsPwr100):
         topic = f'{self.node.alias}/{GsPwr100_Maker.mp_alias}'
+        self.screen_print(f"Trying to publish")
         self.publish_client.publish(
             topic=topic,
             payload=payload.asbinary(),
             qos = QOS.AtMostOnce.value,
             retain=False)
-        self.screen_print(f"Just published {payload} to topic {topic}")
+
 
     @abstractproperty
     def my_meter(self) ->ShNode:

--- a/gw_spaceheat/actors/sensor/sensor_base.py
+++ b/gw_spaceheat/actors/sensor/sensor_base.py
@@ -20,12 +20,13 @@ class SensorBase(ActorBase):
         self.screen_print(f"{message.topic} subscription not implemented!")
     
     def publish_gt_telemetry_1_0_1(self, payload: GtTelemetry101):
+        self.screen_print(f"Trying to publish")
         topic = f'{self.node.alias}/{GtTelemetry101_Maker.mp_alias}'
         self.publish_client.publish(topic=topic, 
                             payload=json.dumps(payload.asdict()),
                             qos = QOS.AtLeastOnce.value,
                             retain=False)
-        self.screen_print(f"Just published {payload} to topic {topic}")
+
 
     
         

--- a/gw_spaceheat/template_settings.py
+++ b/gw_spaceheat/template_settings.py
@@ -1,3 +1,3 @@
 #MQTT related
-MQTT_BROKER_ADDRESS = 'localhost'
+MQTT_BROKER_ADDRESS = 'mqtt.eclipseprojects.io'
 MQTT_USER_NAME = None


### PR DESCRIPTION
The code was missing a key loop_start() command for the publishing client (line 19 of actor_base.py).

Left a hack for starting to set up some decent logging (LOGGING_ON at the top of actor_base.py)

Pending issue regarding length of client_id - some brokers have an id limit of 23 characters. Not resolved yet.