### PR TITLE
Temporary logging in scada code for temperature calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ SassyMQ
 .idea
 .env
 settings.py
-
+tmp.csv

--- a/gw_spaceheat/actors/power_meter/power_meter_base.py
+++ b/gw_spaceheat/actors/power_meter/power_meter_base.py
@@ -17,7 +17,7 @@ class PowerMeterBase(ActorBase):
 
     def publish_gs_pwr(self, payload: GsPwr100):
         topic = f'{self.node.alias}/{GsPwr100_Maker.mp_alias}'
-        self.screen_print("Trying to publish")
+        self.screen_print(f"Trying to publish {payload} to topic {topic}")
         self.publish_client.publish(topic=topic, 
                             payload=payload.asbinary(),
                             qos = QOS.AtMostOnce.value,

--- a/gw_spaceheat/actors/primary_scada/primary_scada_base.py
+++ b/gw_spaceheat/actors/primary_scada/primary_scada_base.py
@@ -49,7 +49,7 @@ class PrimaryScadaBase(ActorBase):
 
     def publish_gs_pwr(self, payload: GsPwr100):
         topic = f'{self.node.alias}/{GsPwr100_Maker.mp_alias}'
-        self.screen_print(f"Trying to publish")
+        self.screen_print(f"Trying to publish {payload} to topic {topic}")
         self.publish_client.publish(
             topic=topic,
             payload=payload.asbinary(),

--- a/gw_spaceheat/actors/sensor/sensor_base.py
+++ b/gw_spaceheat/actors/sensor/sensor_base.py
@@ -20,8 +20,8 @@ class SensorBase(ActorBase):
         self.screen_print(f"{message.topic} subscription not implemented!")
     
     def publish_gt_telemetry_1_0_1(self, payload: GtTelemetry101):
-        self.screen_print(f"Trying to publish")
         topic = f'{self.node.alias}/{GtTelemetry101_Maker.mp_alias}'
+        self.screen_print(f"Trying to publish {payload} to topic {topic}")
         self.publish_client.publish(topic=topic, 
                             payload=json.dumps(payload.asdict()),
                             qos = QOS.AtLeastOnce.value,

--- a/gw_spaceheat/run_temp_sensors.py
+++ b/gw_spaceheat/run_temp_sensors.py
@@ -1,0 +1,19 @@
+import platform
+from data_classes.sh_node import ShNode
+from data_classes.cacs.temp_sensor_cac import TempSensorCac
+from actors.strategy_switcher import main as strategy_switcher
+import load_house
+
+
+if platform.platform() == 'Linux-4.19.118-v7l+-armv7l-with-glibc2.28':
+    load_house.load_all(house_json_file='input_data/pi_dev_house.json')
+else:
+    load_house.load_all(house_json_file='input_data/dev_house.json')
+
+nodes_w_components = list(filter(lambda x: x.primary_component_id is not None, ShNode.by_alias.values()))
+actor_nodes_w_components = list(filter(lambda x: x.python_actor_name is not None, nodes_w_components))
+temp_sensor_nodes = list(filter(lambda x: isinstance(x.primary_component.cac, TempSensorCac), actor_nodes_w_components))
+
+for node in temp_sensor_nodes:
+    (actor_function, keys) = strategy_switcher(node.python_actor_name)
+    sensor = actor_function(node)


### PR DESCRIPTION
We now have 5 temperature sensors installed in the Axeman water tank, and George wants to start collecting data ASAP.

run_temp_sensors.py will read and send the data for all 5, and scada writes the data it gets to a tmp.csv file.

Opportunities for improvement:
  - timestamp for reading should be generated by the sensor actor, otherwise hiccups in the MQTT broker will mean we get an incorrect timestamp.
  - scada sends the data up to the atn, which then does something more sensible with the data.