### PR TITLE
client ids 23 char random

### DIFF
--- a/gw_spaceheat/README.md
+++ b/gw_spaceheat/README.md
@@ -42,7 +42,6 @@ Settings use a gitignored settings.py file. There is a template settings_templat
 For development purposes, you can set up .env to include MQTT_PW = None and use the default value in settings_template.py (one of the 
 many free cloud brokers))
 
-KNOWN ISSUE: some brokers restrict client_id to 23 characters. Our pattern right now is to use the node alias plus '-pub' for the publish client. We'll need to change that pattern since some of our aliases will be longer than 23 characters.
 ## Step 2: input data and running the code
 
 Input data is in input_data folder. The `dev_house.json` is used for developing on a mac. The `pi_dev_house.json` is used for a pi that is connected to actual hardware and has its various drivers (like i2c) enabled.

--- a/gw_spaceheat/actors/actor_base.py
+++ b/gw_spaceheat/actors/actor_base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import paho.mqtt.client as mqtt
+import uuid
 import threading
 from typing import List
 from data_classes.sh_node import ShNode
@@ -13,13 +14,15 @@ class ActorBase(ABC):
     def __init__(self, node: ShNode):
         self.node = node
         self.mqttBroker = settings.MQTT_BROKER_ADDRESS
-        self.publish_client = mqtt.Client(f"{node.alias}-pub")
+        self.publish_client_id = ('-').join(str(uuid.uuid4()).split('-')[:-1])
+        self.publish_client = mqtt.Client(self.publish_client_id)
         self.publish_client.username_pw_set(username=settings.MQTT_USER_NAME, password=helpers.get_secret('MQTT_PW'))
         self.publish_client.connect(self.mqttBroker)
         self.publish_client.loop_start()
         if LOGGING_ON:
             self.publish_client.on_log = self.on_log
-        self.consume_client = mqtt.Client(f"{node.alias}")
+        self.consume_client_id = ('-').join(str(uuid.uuid4()).split('-')[:-1])
+        self.consume_client = mqtt.Client(self.consume_client_id)
         self.consume_client.username_pw_set(username=settings.MQTT_USER_NAME, password=helpers.get_secret('MQTT_PW'))
         self.consume_client.connect(self.mqttBroker)
         if LOGGING_ON:


### PR DESCRIPTION
Some MQTT brokers have a limit of 23 characters on their client_ids. Respecting that bound so we don't have to worry about it by grabbing the initial 23 character string of a uuid.uuid4(). 