### PR TITLE
Add Coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,21 +1,20 @@
 name: Run Python Tests
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  push
+
+env:
+  PYTHONPATH: gw_spaceheat:$PYTHONPATH
+  PYTHON_VERSION: 3.8.6
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.6
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -30,7 +29,30 @@ jobs:
         with:
           source: "test/test_dotenv"
           target: ".env"
-      - name: Run tests with pytest
-        run: pytest
-        env:
-          PYTHONPATH: gw_spaceheat:$PYTHONPATH
+      - name: Run tests with pytest under coverage
+        run: coverage run --omit gw_spaceheat/settings.py -m pytest
+      - name: Upload coverage data
+        uses: "actions/upload-artifact@v3"
+        with:
+          name: coverage-data
+          path: ".coverage*"
+
+  coverage_report:
+    name: Combine & check coverage.
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: python -m pip install --upgrade coverage[toml]
+      - name: Download coverage data.
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-data
+      - name: Report and upload
+        run: |
+          python -m coverage xml
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3.1.0

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ SassyMQ
 .env
 settings.py
 tmp.csv
+
+.coverage
+htmlcov

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GridWorks SpaceHeat SCADA
 
 [![Tests](https://github.com/anschweitzer/gw-scada-spaceheat-python/actions/workflows/ci.yaml/badge.svg)][tests]
-[![Codecov](https://codecov.io/gh/anschweitzer/gw-scada-spaceheat-python/branch/as/coverage/graph/badge.svg)][codecov]
+[![Codecov](https://codecov.io/gh/anschweitzer/gw-scada-spaceheat-python/branch/main/graph/badge.svg)][codecov]
 
 [tests]: https://github.com/anschweitzer/gw-scada-spaceheat-python/actions/workflows/ci.yaml
 [codecov]: https://app.codecov.io/gh/anschweitzer/gw-scada-spaceheat-python

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # GridWorks SpaceHeat SCADA
 
+[![Tests](https://github.com/anschweitzer/gw-scada-spaceheat-python/actions/workflows/ci.yaml/badge.svg)][tests]
+[![Codecov](https://codecov.io/gh/anschweitzer/gw-scada-spaceheat-python/branch/as/coverage/graph/badge.svg)][codecov]
+
+[tests]: https://github.com/anschweitzer/gw-scada-spaceheat-python/actions/workflows/ci.yaml
+[codecov]: https://app.codecov.io/gh/anschweitzer/gw-scada-spaceheat-python
+
+
 This code is intended to run on a raspberry Pi 4 attached to a number of actuating and sensing devices. It is for running a heat pump thermal storage heating system in a house, and doing this _transactively_. That means the heating system is capable of dynamically responding to local electric grid conditions and buying energy at the lowest cost times, while keeping the house warm. Most of the time, the decisions for when to charge the heating system (and how to participate in electricity markets) are made by an agent outside of the home's LAN - this agent is called the AtomicTransactive Node or AtomicTNode for short. 
 
 The SCADA It does 5 main things:

--- a/gw_spaceheat/requirements/dev.txt
+++ b/gw_spaceheat/requirements/dev.txt
@@ -18,6 +18,8 @@ click==8.1.3
     # via
     #   black
     #   pip-tools
+coverage==6.4.1
+    # via -r requirements/test.in
 decorator==5.1.1
     # via ipython
 executing==0.8.3

--- a/gw_spaceheat/requirements/test.in
+++ b/gw_spaceheat/requirements/test.in
@@ -1,2 +1,3 @@
 nose
 pytest
+coverage

--- a/gw_spaceheat/requirements/test.txt
+++ b/gw_spaceheat/requirements/test.txt
@@ -6,6 +6,8 @@
 #
 attrs==21.4.0
     # via pytest
+coverage==6.4.1
+    # via -r requirements/test.in
 iniconfig==1.1.1
     # via pytest
 nose==1.3.7


### PR DESCRIPTION
Automatic and manual coverage commands. 

* Modifies CI to run on *every* push, not just pushes to main and pull requests. This is not strictly necessary for coverage, but it was useful for testing and seems like a good idea. 
* Runs coverage in CI. 
* Uploads results to CodeCov.
* Shows testing and coverage badges on README.md. (Visualize [here](https://github.com/anschweitzer/gw-scada-spaceheat-python#readme)).
* Adds requirements for coverage library. 