### PR TITLE
garage config changes - only one tank temp sensor

### DIFF
--- a/gw_spaceheat/input_data/houses.json
+++ b/gw_spaceheat/input_data/houses.json
@@ -571,43 +571,7 @@
                     "RoleGtEnumSymbol": "73308a1f",
                     "DisplayName": "Tank temp sensor temp0 (on top)",
                     "ShNodeId": "3593a10a-4335-447a-b62e-e123788a134a",
-                    "ComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
-                    "ReportingSamplePeriodS": 5,
-                    "HasActor": true
-                },
-                {
-                    "Alias": "a.tank.temp1",
-                    "RoleGtEnumSymbol": "73308a1f",
-                    "DisplayName": "Tank temp sensor temp1 (second from top)",
-                    "ShNodeId": "0df93059-f155-4c4f-a43c-0265a28f21fb",
-                    "ComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
-                    "ReportingSamplePeriodS": 5,
-                    "HasActor": true
-                },
-                {
-                    "Alias": "a.tank.temp2",
-                    "RoleGtEnumSymbol": "73308a1f",
-                    "DisplayName": "Tank temp sensor temp2 (third from top)",
-                    "ShNodeId": "17f84be9-6237-4331-91f8-17452eba0345",
-                    "ComponentId": "fef75047-6416-46d1-bd08-1c10beefa69d",
-                    "ReportingSamplePeriodS": 5,
-                    "HasActor": true
-                },
-                {
-                    "Alias": "a.tank.temp3",
-                    "RoleGtEnumSymbol": "73308a1f",
-                    "DisplayName": "Tank temp sensor temp3 (fourth from top)",
-                    "ShNodeId": "296c9002-5771-4e11-969c-48a6db905b83",
-                    "ComponentId": "14330fc6-c26e-4b74-9000-87e10da65828",
-                    "ReportingSamplePeriodS": 5,
-                    "HasActor": true
-                },
-                {
-                    "Alias": "a.tank.temp4",
-                    "RoleGtEnumSymbol": "73308a1f",
-                    "DisplayName": "Tank temp sensor temp4 (fifth from top)",
-                    "ShNodeId": "0680a809-d56f-42d8-8d98-e7c23e94d311",
-                    "ComponentId": "2ca9e65a-5e85-4eaa-811b-901e940f8d09",
+                    "ComponentId": "2d4b3b73-fc58-4789-b15e-9881f0b4ff40",
                     "ReportingSamplePeriodS": 5,
                     "HasActor": true
                 },
@@ -702,34 +666,10 @@
                     "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318"
                 },
                 {
-                    "ComponentId": "f516467e-7691-42c8-8525-f7d49bb135ce",
+                    "ComponentId": "2d4b3b73-fc58-4789-b15e-9881f0b4ff40",
                     "DisplayName": "Component for a.tank.temp0 (on top)",
                     "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
-                    "HwUid": "0003debb"
-                },
-                {
-                    "ComponentId": "d8d9f2b6-db8b-4a23-a037-20c7308ec56e",
-                    "DisplayName": "Component for a.tank.temp1 (second from top)",
-                    "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
-                    "HwUid": "0003c2c4"
-                },
-                {
-                    "ComponentId": "fef75047-6416-46d1-bd08-1c10beefa69d",
-                    "DisplayName": "Component for a.tank.temp2 (third from top)",
-                    "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
-                    "HwUid": "00034a8f"
-                },
-                {
-                    "ComponentId": "14330fc6-c26e-4b74-9000-87e10da65828",
-                    "DisplayName": "Component for a.tank.temp3 (fourth from top)",
-                    "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
-                    "HwUid": "00039d4b"
-                },
-                {
-                    "ComponentId": "2ca9e65a-5e85-4eaa-811b-901e940f8d09",
-                    "DisplayName": "Component for a.tank.temp4 (fifth from top)",
-                    "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
-                    "HwUid": "00033ffe"
+                    "HwUid": "00041d3f"
                 },
                 {
                     "ComponentId": "23a09f17-741a-49b2-afbc-04f17f476594",


### PR DESCRIPTION
The five 1-wire `Adafruit 642` temperature sensors inside the big Axeman water tank were failing in a variety of ways. We think water was getting into the electronics inside one or more of the sensors themselves, through the (attempted waterproof) splicing job we had done.

So George pulled them out, and replaced them with a single `Adafruit 642` which is up near the top. That means `a.tank.temp1` .. `a.tank.temp4` no longer exist as nodes, and `a.tank.temp0` has a new component.