### PR TITLE
pipe temp sensor added in garage

### DIFF
--- a/gw_spaceheat/actors/pipe_temp_sensor.py
+++ b/gw_spaceheat/actors/pipe_temp_sensor.py
@@ -1,0 +1,59 @@
+import time
+from typing import List
+
+from data_classes.node_config import NodeConfig
+from data_classes.sh_node import ShNode
+from schema.gt.gt_telemetry.gt_telemetry_maker import GtTelemetry_Maker
+
+from actors.actor_base import ActorBase
+from actors.utils import Subscription
+
+
+class PipeTempSensor(ActorBase):
+    MAIN_LOOP_MIN_TIME_S = 0.2
+
+    def __init__(self, node: ShNode, logging_on=False):
+        super(PipeTempSensor, self).__init__(node=node, logging_on=logging_on)
+        self._last_sent_s = 0
+        self._sent_latest_sample = False
+        self.temp = None
+        self.config = NodeConfig(self.node)
+        self.screen_print(f"Initialized {self.__class__}")
+
+    def subscriptions(self) -> List[Subscription]:
+        return []
+
+    def on_message(self, from_node: ShNode, payload):
+        pass
+
+    def check_and_report_temp(self):
+        check_start_s = time.time()
+        sample_period_s = self.config.reporting.SamplePeriodS
+        telemetry_name = self.config.reporting.TelemetryName
+        exponent = self.config.reporting.Exponent
+        if int(check_start_s + self.config.typical_response_time_ms / 1000) % sample_period_s == 0:
+            self.temp = self.config.driver.read_temp()
+            time_of_read_s = time.time()
+            if int(time_of_read_s) > self._last_sent_s:
+                payload = GtTelemetry_Maker(
+                    name=telemetry_name,
+                    value=int(self.temp),
+                    exponent=exponent,
+                    scada_read_time_unix_ms=int(time_of_read_s * 1000),
+                ).tuple
+                self.publish(payload=payload)
+                self.screen_print(f"{payload.Value} {telemetry_name.value}")
+                # self.screen_print(f"{int(time_of_read_s * 1000)}")
+                self._sent_latest_sample = True
+                self._last_sent_s = int(time_of_read_s)
+        else:
+            time_of_read_s = check_start_s
+        if (time_of_read_s - check_start_s) > self.MAIN_LOOP_MIN_TIME_S:
+            return
+        wait_time_s = self.MAIN_LOOP_MIN_TIME_S - (time_of_read_s - check_start_s)
+        time.sleep(wait_time_s)
+
+    def main(self):
+        self._main_loop_running = True
+        while self._main_loop_running is True:
+            self.check_and_report_temp()

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -33,6 +33,11 @@ class Scada(ScadaBase):
         all_nodes = list(ShNode.by_alias.values())
         return list(filter(lambda x: x.role == Role.BOOLEAN_ACTUATOR, all_nodes))
 
+    @classmethod
+    def my_pipe_temp_sensors(cls) -> List[ShNode]:
+        all_nodes = list(ShNode.by_alias.values())
+        return list(filter(lambda x: x.role == Role.PIPE_TEMP_SENSOR, all_nodes))
+
     def __init__(self, node: ShNode, logging_on=False):
         super(Scada, self).__init__(node=node, logging_on=logging_on)
         now = int(time.time())
@@ -47,7 +52,8 @@ class Scada(ScadaBase):
         self.screen_print(f"Initialized {self.__class__}")
 
     def flush_latest_readings(self):
-        for node in self.my_tank_water_temp_sensors() + self.my_boolean_actuators():
+        for node in self.my_tank_water_temp_sensors() + self.my_boolean_actuators() \
+                + self.my_pipe_temp_sensors():
             self.latest_readings[node] = []
             self.latest_sample_times_ms[node] = []
 

--- a/gw_spaceheat/actors/strategy_switcher.py
+++ b/gw_spaceheat/actors/strategy_switcher.py
@@ -5,6 +5,7 @@ from actors.atn import Atn
 from actors.boolean_actuator import BooleanActuator
 from actors.home_alone import HomeAlone
 from actors.pipe_flow_meter import PipeFlowMeter
+from actors.pipe_temp_sensor import PipeTempSensor
 from actors.power_meter import PowerMeter
 from actors.scada import Scada
 from actors.tank_water_temp_sensor import TankWaterTempSensor
@@ -14,6 +15,7 @@ switcher = {
     Role.BOOLEAN_ACTUATOR: BooleanActuator,
     Role.HOME_ALONE: HomeAlone,
     Role.PIPE_FLOW_METER: PipeFlowMeter,
+    Role.PIPE_TEMP_SENSOR: PipeTempSensor,
     Role.POWER_METER: PowerMeter,
     Role.SCADA: Scada,
     Role.TANK_WATER_TEMP_SENSOR: TankWaterTempSensor,

--- a/gw_spaceheat/input_data/houses.json
+++ b/gw_spaceheat/input_data/houses.json
@@ -119,7 +119,7 @@
                     "HasActor": true
                 },
                 {
-                    "Alias": "a.tank.out.tempmeter1",
+                    "Alias": "a.tank.out.temp1",
                     "RoleGtEnumSymbol": "c480f612",
                     "DisplayName": "Temp Sensor on distribution pipe out of tank",
                     "ShNodeId": "66a4a5e7-f160-424a-8ad5-f6554bf9a99a",
@@ -128,7 +128,7 @@
                     "HasActor": false
                 },
                 {
-                    "Alias": "a.tank.in.tempmeter1",
+                    "Alias": "a.tank.in.temp1",
                     "RoleGtEnumSymbol": "c480f612",
                     "DisplayName": "Temp Sensor on distribution pipe into tank",
                     "ShNodeId": "d9c461f6-ed11-4dc1-9fe2-992d5d2413d0",
@@ -549,16 +549,16 @@
                     "HasActor": true
                 },
                 {
-                    "Alias": "a.tank.out.tempmeter1",
+                    "Alias": "a.tank.out.temp1",
                     "RoleGtEnumSymbol": "c480f612",
                     "DisplayName": "Temp Sensor on distribution pipe out of tank",
                     "ShNodeId": "66a4a5e7-f160-424a-8ad5-f6554bf9a99a",
-                    "ComponentId": "a16d7bb6-2606-4ad1-b6b4-be80b5d84a6e",
-                    "ReportingSamplePeriodS": 60,
-                    "HasActor": false
+                    "ComponentId": "2ca9e65a-5e85-4eaa-811b-901e940f8d09",
+                    "ReportingSamplePeriodS": 5,
+                    "HasActor": true
                 },
                 {
-                    "Alias": "a.tank.in.tempmeter1",
+                    "Alias": "a.tank.in.temp1",
                     "RoleGtEnumSymbol": "c480f612",
                     "DisplayName": "Temp Sensor on distribution pipe into tank",
                     "ShNodeId": "d9c461f6-ed11-4dc1-9fe2-992d5d2413d0",
@@ -656,9 +656,10 @@
                     "ComponentAttributeClassId": "cac0f096-b460-4dce-aabf-a81ccce23566"
                 },
                 {
-                    "ComponentId": "a16d7bb6-2606-4ad1-b6b4-be80b5d84a6e",
+                    "ComponentId": "2ca9e65a-5e85-4eaa-811b-901e940f8d09",
                     "DisplayName": "Temp sensor on pipe out of tank",
-                    "ComponentAttributeClassId": "d95af339-9f2b-45aa-9133-04f267ef0318"
+                    "ComponentAttributeClassId": "43564cd2-0e78-41a2-8b67-ad80c02161e8",
+                    "HwUid": "00033ffe"
                 },
                 {
                     "ComponentId": "efabaa6a-e331-491f-9dbb-a3dee0029531",

--- a/test/test_data/test_collect_temp.json
+++ b/test/test_data/test_collect_temp.json
@@ -119,7 +119,7 @@
                     "HasActor": true
                 },
                 {
-                    "Alias": "a.tank.out.tempmeter1",
+                    "Alias": "a.tank.out.temp1",
                     "RoleGtEnumSymbol": "c480f612",
                     "DisplayName": "Temp Sensor on distribution pipe out of tank",
                     "ShNodeId": "66a4a5e7-f160-424a-8ad5-f6554bf9a99a",
@@ -128,7 +128,7 @@
                     "HasActor": false
                 },
                 {
-                    "Alias": "a.tank.in.tempmeter1",
+                    "Alias": "a.tank.in.temp1",
                     "RoleGtEnumSymbol": "c480f612",
                     "DisplayName": "Temp Sensor on distribution pipe into tank",
                     "ShNodeId": "d9c461f6-ed11-4dc1-9fe2-992d5d2413d0",

--- a/test/test_data/test_load_house.json
+++ b/test/test_data/test_load_house.json
@@ -119,7 +119,7 @@
                     "HasActor": true
                 },
                 {
-                    "Alias": "a.tank.out.tempmeter1",
+                    "Alias": "a.tank.out.temp1",
                     "RoleGtEnumSymbol": "c480f612",
                     "DisplayName": "Temp Sensor on distribution pipe out of tank",
                     "ShNodeId": "66a4a5e7-f160-424a-8ad5-f6554bf9a99a",
@@ -128,7 +128,7 @@
                     "HasActor": false
                 },
                 {
-                    "Alias": "a.tank.in.tempmeter1",
+                    "Alias": "a.tank.in.temp1",
                     "RoleGtEnumSymbol": "c480f612",
                     "DisplayName": "Temp Sensor on distribution pipe into tank",
                     "ShNodeId": "d9c461f6-ed11-4dc1-9fe2-992d5d2413d0",


### PR DESCRIPTION
Simplification in order ... likely silly to have different actor
classes for different temp sensors

In any case, we've used one of the old 1-wire temperature sensors that used to be inside the tank, zip-tied it to the pipe, used a piece of copper wire to help bind it, shmeared it all with thermal grease (sensor about half-deep in it), wrapped in duct tape, and then wrapped the whole thing in about 4 inches of insulation.

That'll have to do until I've got a2d working for the actual pipe temp sensor thermisters.

