### PR TITLE
Jm/debug pipe

### DIFF
--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -174,7 +174,8 @@ class Scada(ScadaBase):
     def send_status(self):
         self.screen_print("Should send status")
         simple_single_status_list = []
-        for node in self.my_tank_water_temp_sensors() + self.my_boolean_actuators():
+        for node in self.my_tank_water_temp_sensors() + self.my_boolean_actuators() \
+            + self.my_pipe_temp_sensors():
             single_status = self.make_single_status(node)
             if single_status:
                 simple_single_status_list.append(self.make_single_status(node))

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -69,7 +69,8 @@ class Scada(ScadaBase):
     def subscriptions(self) -> List[Subscription]:
         my_subscriptions = [Subscription(Topic=f"a.m/{GsPwr_Maker.type_alias}", Qos=QOS.AtMostOnce)]
 
-        for node in self.my_tank_water_temp_sensors() + self.my_boolean_actuators():
+        for node in self.my_tank_water_temp_sensors() + self.my_boolean_actuators() + \
+                self.my_pipe_temp_sensors():
             my_subscriptions.append(
                 Subscription(
                     Topic=f"{node.alias}/{GtTelemetry_Maker.type_alias}", Qos=QOS.AtLeastOnce

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -175,7 +175,7 @@ class Scada(ScadaBase):
         self.screen_print("Should send status")
         simple_single_status_list = []
         for node in self.my_tank_water_temp_sensors() + self.my_boolean_actuators() \
-            + self.my_pipe_temp_sensors():
+                + self.my_pipe_temp_sensors():
             single_status = self.make_single_status(node)
             if single_status:
                 simple_single_status_list.append(self.make_single_status(node))


### PR DESCRIPTION
evidence for why simplifying the actors would be a good idea. Should probably decouple `Role` from `Actor` - the same kind of actor (e.g. temp sensor) can play multiple `Roles`