### PR TITLE
Little step in debugging mqtt fails

### DIFF
--- a/gw_spaceheat/actors/actor_base.py
+++ b/gw_spaceheat/actors/actor_base.py
@@ -35,9 +35,9 @@ class ActorBase(ABC):
             username=settings.LOCAL_MQTT_USER_NAME,
             password=helpers.get_secret("LOCAL_MQTT_PW"),
         )
-        self.publish_client.on_connect = self.on_connect
-        self.publish_client.on_connect_fail = self.on_connect_fail
-        self.publish_client.on_disconnect = self.on_disconnect
+        self.publish_client.on_connect = self.on_publish_connect
+        self.publish_client.on_connect_fail = self.on_publish_connect_fail
+        self.publish_client.on_disconnect = self.on_publish_disconnect
         self.publish_client.connect(self.mqttBroker)
         if self.logging_on:
             self.publish_client.on_log = self.on_log
@@ -48,9 +48,9 @@ class ActorBase(ABC):
             password=helpers.get_secret("LOCAL_MQTT_PW"),
         )
         self.consume_client.on_message = self.on_mqtt_message
-        self.consume_client.on_connect = self.on_connect
-        self.consume_client.on_connect_fail = self.on_connect_fail
-        self.consume_client.on_disconnect = self.on_disconnect
+        self.consume_client.on_connect = self.on_consume_connect
+        self.consume_client.on_connect_fail = self.on_consume_connect_fail
+        self.consume_client.on_disconnect = self.on_consume_disconnect
         self.consume_client.connect(self.mqttBroker)
         if self.logging_on:
             self.consume_client.on_log = self.on_log
@@ -70,18 +70,32 @@ class ActorBase(ABC):
         self.mqtt_log_hack([f"({helpers.log_time()}) log: {buf}"])
 
     # noinspection PyUnusedLocal
-    def on_connect(self, client, userdata, flags, rc):
+    def on_publish_connect(self, client, userdata, flags, rc):
         self.mqtt_log_hack(
-            [f"({helpers.log_time()}) Connected flags {str(flags)} + result code {str(rc)}"]
+            [f"({helpers.log_time()}) Local Publish Connected flags {str(flags)} + result code {str(rc)}"]
         )
 
     # noinspection PyUnusedLocal
-    def on_connect_fail(self, client, userdata, rc):
-        self.mqtt_log_hack([f"({helpers.log_time()}) Connect fail! result code {str(rc)}"])
+    def on_publish_connect_fail(self, client, userdata, rc):
+        self.mqtt_log_hack([f"({helpers.log_time()}) Local Publish Connect fail! result code {str(rc)}"])
 
     # noinspection PyUnusedLocal
-    def on_disconnect(self, client, userdata, rc):
-        self.mqtt_log_hack([f"({helpers.log_time()}) Disconnected! result code {str(rc)}"])
+    def on_publish_disconnect(self, client, userdata, rc):
+        self.mqtt_log_hack([f"({helpers.log_time()}) Local Publish Disconnected! result code {str(rc)}"])
+    
+        # noinspection PyUnusedLocal
+    def on_consume_connect(self, client, userdata, flags, rc):
+        self.mqtt_log_hack(
+            [f"({helpers.log_time()}) Local Consume Connected flags {str(flags)} + result code {str(rc)}"]
+        )
+
+    # noinspection PyUnusedLocal
+    def on_consume_connect_fail(self, client, userdata, rc):
+        self.mqtt_log_hack([f"({helpers.log_time()}) Local Consume Connect fail! result code {str(rc)}"])
+
+    # noinspection PyUnusedLocal
+    def on_consume_disconnect(self, client, userdata, rc):
+        self.mqtt_log_hack([f"({helpers.log_time()}) Local Consume Disconnected! result code {str(rc)}"])
 
     @abstractmethod
     def subscriptions(self) -> List[Subscription]:

--- a/gw_spaceheat/actors/scada_base.py
+++ b/gw_spaceheat/actors/scada_base.py
@@ -35,9 +35,9 @@ class ScadaBase(ActorBase):
         self.gw_publish_client.username_pw_set(
             username=settings.GW_MQTT_USER_NAME, password=helpers.get_secret("GW_MQTT_PW")
         )
-        self.gw_publish_client.on_connect = self.on_connect
-        self.gw_publish_client.on_connect_fail = self.on_connect_fail
-        self.gw_publish_client.on_disconnect = self.on_disconnect
+        self.gw_publish_client.on_connect = self.on_gw_publish_connect
+        self.gw_publish_client.on_connect_fail = self.on_gw_publish_connect_fail
+        self.gw_publish_client.on_disconnect = self.on_gw_publish_disconnect
         self.gw_publish_client.connect(self.gwMqttBroker)
         self.gw_publish_client.loop_start()
         if self.logging_on:
@@ -48,15 +48,43 @@ class ScadaBase(ActorBase):
             username=settings.GW_MQTT_USER_NAME, password=helpers.get_secret("GW_MQTT_PW")
         )
         self.gw_consume_client.on_message = self.on_gw_mqtt_message
-        self.gw_consume_client.on_connect = self.on_connect
-        self.gw_consume_client.on_connect_fail = self.on_connect_fail
-        self.gw_consume_client.on_disconnect = self.on_disconnect
+        self.gw_consume_client.on_connect = self.on_gw_consume_connect
+        self.gw_consume_client.on_connect_fail = self.on_gw_consume_connect_fail
+        self.gw_consume_client.on_disconnect = self.on_gw_consume_disconnect
         self.gw_consume_client.connect(self.gwMqttBroker)
         if self.logging_on:
             self.gw_consume_client.on_log = self.on_log
         self.gw_consume_client.subscribe(
             list(map(lambda x: (f"{x.Topic}", x.Qos.value), self.gw_subscriptions()))
         )
+
+    # noinspection PyUnusedLocal
+    def on_gw_publish_connect(self, client, userdata, flags, rc):
+        self.mqtt_log_hack(
+            [f"({helpers.log_time()}) GW Publish Connected flags {str(flags)} + result code {str(rc)} + "
+             f" userdata {str(userdata)}"]
+        )
+
+    # noinspection PyUnusedLocal
+    def on_gw_publish_connect_fail(self, client, userdata, rc):
+        self.mqtt_log_hack([f"({helpers.log_time()}) GW Publish Connect fail! result code {str(rc)}"])
+
+    # noinspection PyUnusedLocal
+    def on_gw_publish_disconnect(self, client, userdata, rc):
+        self.mqtt_log_hack([f"({helpers.log_time()}) GW Publish disconnected! result code {str(rc)}"])
+
+    def on_gw_consume_connect(self, client, userdata, flags, rc):
+        self.mqtt_log_hack(
+            [f"({helpers.log_time()}) GW Consume Connected flags {str(flags)} + result code {str(rc)}"]
+        )
+
+    # noinspection PyUnusedLocal
+    def on_gw_consume_connect_fail(self, client, userdata, rc):
+        self.mqtt_log_hack([f"({helpers.log_time()}) GW Consume Connect fail! result code {str(rc)}"])
+
+    # noinspection PyUnusedLocal
+    def on_gw_consume_disconnect(self, client, userdata, rc):
+        self.mqtt_log_hack([f"({helpers.log_time()}) GW Consume disconnected! result code {str(rc)}"])
 
     # noinspection PyUnusedLocal
     def on_gw_mqtt_message(self, client, userdata, message):

--- a/gw_spaceheat/schema/gt/gt_heartbeat_a/gt_heartbeat_a.py
+++ b/gw_spaceheat/schema/gt/gt_heartbeat_a/gt_heartbeat_a.py
@@ -1,0 +1,15 @@
+"""gt.heartbeat.a type"""
+
+from schema.errors import MpSchemaError
+from schema.gt.gt_heartbeat_a.gt_heartbeat_a_base import GtHeartbeatABase
+
+
+class GtHeartbeatA(GtHeartbeatABase):
+
+    def check_for_errors(self):
+        errors = self.derived_errors() + self.hand_coded_errors()
+        if len(errors) > 0:
+            raise MpSchemaError(f" Errors making making gt.heartbeat.a for {self}: {errors}")
+
+    def hand_coded_errors(self):
+        return []

--- a/gw_spaceheat/schema/gt/gt_heartbeat_a/gt_heartbeat_a_base.py
+++ b/gw_spaceheat/schema/gt/gt_heartbeat_a/gt_heartbeat_a_base.py
@@ -1,0 +1,22 @@
+"""Base for gt.heartbeat.a"""
+import json
+from typing import List, Optional, NamedTuple
+import schema.property_format as property_format
+
+
+class GtHeartbeatABase(NamedTuple):
+    TypeAlias: str = 'gt.heartbeat.a.100'
+
+    def as_type(self):
+        return json.dumps(self.asdict())
+
+    def asdict(self):
+        d = self._asdict()
+        return d
+
+    def derived_errors(self) -> List[str]:
+        errors = []
+        if self.TypeAlias != 'gt.heartbeat.a.100':
+            errors.append(f"Type requires TypeAlias of gt.heartbeat.a.100, not {self.TypeAlias}.")
+        
+        return errors

--- a/gw_spaceheat/schema/gt/gt_heartbeat_a/gt_heartbeat_a_maker.py
+++ b/gw_spaceheat/schema/gt/gt_heartbeat_a/gt_heartbeat_a_maker.py
@@ -1,0 +1,40 @@
+"""Makes gt.heartbeat.a type"""
+
+import json
+from typing import Dict, Optional
+
+
+from schema.gt.gt_heartbeat_a.gt_heartbeat_a import GtHeartbeatA
+from schema.errors import MpSchemaError
+
+
+class GtHeartbeatA_Maker():
+    type_alias = 'gt.heartbeat.a.100'
+
+    def __init__(self):
+
+        tuple = GtHeartbeatA()
+        tuple.check_for_errors()
+        self.tuple = tuple
+
+    @classmethod
+    def tuple_to_type(cls, tuple: GtHeartbeatA) -> str:
+        tuple.check_for_errors()
+        return tuple.as_type()
+
+    @classmethod
+    def type_to_tuple(cls, t: str) -> GtHeartbeatA:
+        try:
+            d = json.loads(t)
+        except TypeError:
+            raise MpSchemaError(f'Type must be string or bytes!')
+        if not isinstance(d, dict):
+            raise MpSchemaError(f"Deserializing {t} must result in dict!")
+        return cls.dict_to_tuple(d)
+
+    @classmethod
+    def dict_to_tuple(cls, d: dict) ->  GtHeartbeatA:
+
+        tuple = GtHeartbeatA()
+        tuple.check_for_errors()
+        return tuple


### PR DESCRIPTION
Will likely get rid of the seperate publish/consume mqtt clients, but as long as they are there might as well differentiate them in the debugging mqtt logs.

Introduced a static heartbeat message for some first experiments with tracking `talking with`