### PR TITLE
Move choice for ear status csv download out of Ear class

### DIFF
--- a/gw_spaceheat/actors/cloud_ear.py
+++ b/gw_spaceheat/actors/cloud_ear.py
@@ -17,20 +17,22 @@ from schema.gt.gt_sh_simple_status.gt_sh_simple_status_maker import (
 from actors.cloud_base import CloudBase
 from actors.utils import QOS, Subscription
 
-atn_ender = settings.ATN_G_NODE_ALIAS.replace(".", "_")
-# OUT_STUB = f'/Users/jess/Google Drive/My Drive/GridWorks/Projects/Internal Maine Heat Pilot/SCADA/data/{atn_ender}'
-OUT_STUB = f"output/status/{atn_ender}"
+OUT_STUB = f"output/status"
 
 
 class CloudEar(CloudBase):
-    def __init__(self, write_to_csv=False, logging_on=False):
-        self.write_to_csv = write_to_csv
+    def __init__(self, out_stub=OUT_STUB, logging_on=False):
+        if out_stub is None:
+            self.write_to_csv = False
+        else:
+            self.write_to_csv = True
         super(CloudEar, self).__init__(logging_on=logging_on)
         self.log_csv = f"output/debug_logs/ear_{str(uuid.uuid4()).split('-')[1]}.csv"
         self.load_sh_nodes()
         if self.write_to_csv:
             adder = str(uuid.uuid4()).split("-")[1]
-            self.out_telemetry = f"{OUT_STUB}_{adder}.csv"
+            atn_ender = settings.ATN_G_NODE_ALIAS.replace(".", "_")
+            self.out_telemetry = f"{out_stub}/{atn_ender}_{adder}.csv"
             self.screen_print(f"writing output headers ending in {adder}")
             with open(self.out_telemetry, "w") as outfile:
                 write = csv.writer(outfile, delimiter=",")

--- a/gw_spaceheat/actors/cloud_ear.py
+++ b/gw_spaceheat/actors/cloud_ear.py
@@ -17,7 +17,7 @@ from schema.gt.gt_sh_simple_status.gt_sh_simple_status_maker import (
 from actors.cloud_base import CloudBase
 from actors.utils import QOS, Subscription
 
-OUT_STUB = f"output/status"
+OUT_STUB = "output/status"
 
 
 class CloudEar(CloudBase):

--- a/gw_spaceheat/run_ear.py
+++ b/gw_spaceheat/run_ear.py
@@ -1,4 +1,4 @@
 from actors.cloud_ear import CloudEar
 
-ear = CloudEar(write_to_csv=True)
+ear = CloudEar()
 ear.start()

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -46,7 +46,7 @@ class EarRecorder(CloudEar):
         self.num_received = 0
         self.num_received_by_topic = defaultdict(int)
         self.latest_payload = None
-        super().__init__()
+        super().__init__(out_stub=None)
 
     def on_gw_mqtt_message(self, client, userdata, message):
         self.num_received += 1


### PR DESCRIPTION
Right now the `ear` is used by either me or George to store status files in google drive. The relative path needs to change depending on whose computer this is running on.

Eventually this should be in aws, but for now I wanted to have the choice happen outside of the `Ear` actor.