### PR TITLE
__init__()/start() cleanup and responsive sleeps

### DIFF
--- a/gw_spaceheat/actors/atn.py
+++ b/gw_spaceheat/actors/atn.py
@@ -1,4 +1,3 @@
-import time
 import uuid
 from typing import Dict, List, Optional
 
@@ -20,7 +19,7 @@ from schema.gt.gt_sh_simple_status.gt_sh_simple_status_maker import (
 )
 
 from actors.cloud_base import CloudBase
-from actors.utils import QOS, Subscription
+from actors.utils import QOS, Subscription, responsive_sleep
 
 
 class Atn(CloudBase):
@@ -126,7 +125,7 @@ class Atn(CloudBase):
     def main(self):
         self._main_loop_running = True
         while self._main_loop_running is True:
-            time.sleep(1)
+            responsive_sleep(self, 1)
 
     def screen_print(self, note):
         header = f"{self.node.alias}: "

--- a/gw_spaceheat/actors/boolean_actuator.py
+++ b/gw_spaceheat/actors/boolean_actuator.py
@@ -8,7 +8,7 @@ from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch, GtDispatch_Maker
 from schema.gt.gt_telemetry.gt_telemetry_maker import GtTelemetry_Maker
 
 from actors.actor_base import ActorBase
-from actors.utils import QOS, Subscription
+from actors.utils import QOS, Subscription, responsive_sleep
 
 
 class BooleanActuator(ActorBase):
@@ -80,7 +80,7 @@ class BooleanActuator(ActorBase):
             if (time_of_read_s - check_start_s) > self.MAIN_LOOP_MIN_TIME_S:
                 return
             wait_time_s = self.MAIN_LOOP_MIN_TIME_S - (time_of_read_s - check_start_s)
-            time.sleep(wait_time_s)
+            responsive_sleep(self, wait_time_s)
 
     @property
     def next_sync_report_time_s(self) -> int:

--- a/gw_spaceheat/actors/cloud_ear.py
+++ b/gw_spaceheat/actors/cloud_ear.py
@@ -15,7 +15,7 @@ from schema.gt.gt_sh_simple_status.gt_sh_simple_status_maker import (
 
 
 from actors.cloud_base import CloudBase
-from actors.utils import QOS, Subscription
+from actors.utils import QOS, Subscription, responsive_sleep
 
 OUT_STUB = "output/status"
 
@@ -98,7 +98,7 @@ class CloudEar(CloudBase):
     def main(self):
         self._main_loop_running = True
         while self._main_loop_running is True:
-            time.sleep(10)
+            responsive_sleep(self, 10)
 
     def screen_print(self, note):
         header = "Cloud Ear: "

--- a/gw_spaceheat/actors/home_alone.py
+++ b/gw_spaceheat/actors/home_alone.py
@@ -1,4 +1,3 @@
-import time
 from typing import List, Optional
 
 import helpers
@@ -9,7 +8,7 @@ from schema.gt.gt_sh_simple_status.gt_sh_simple_status_maker import (
 )
 
 from actors.actor_base import ActorBase
-from actors.utils import QOS, Subscription
+from actors.utils import QOS, Subscription, responsive_sleep
 
 
 class HomeAlone(ActorBase):
@@ -48,4 +47,4 @@ class HomeAlone(ActorBase):
     def main(self):
         self._main_loop_running = True
         while self._main_loop_running is True:
-            time.sleep(1)
+            responsive_sleep(self, 1)

--- a/gw_spaceheat/actors/power_meter.py
+++ b/gw_spaceheat/actors/power_meter.py
@@ -1,12 +1,11 @@
 import random
-import time
 from typing import List
 
 from data_classes.sh_node import ShNode
 from schema.gs.gs_pwr_maker import GsPwr_Maker
 
 from actors.actor_base import ActorBase
-from actors.utils import Subscription
+from actors.utils import Subscription, responsive_sleep
 
 
 class PowerMeter(ActorBase):
@@ -27,4 +26,4 @@ class PowerMeter(ActorBase):
             self.total_power_w += 250 - int(500 * random.random())
             payload = GsPwr_Maker(power=self.total_power_w).tuple
             self.publish(payload=payload)
-            time.sleep(1)
+            responsive_sleep(self, 1)

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -32,7 +32,7 @@ from schema.gt.gt_sh_status_snapshot.gt_sh_status_snapshot_maker import (
 from schema.gt.gt_telemetry.gt_telemetry_maker import GtTelemetry, GtTelemetry_Maker
 
 from actors.scada_base import ScadaBase
-from actors.utils import QOS, Subscription
+from actors.utils import QOS, Subscription, responsive_sleep
 
 
 class Scada(ScadaBase):
@@ -249,7 +249,7 @@ class Scada(ScadaBase):
         while self._main_loop_running is True:
             if self.time_for_5_cron():
                 self.cron_every_5()
-            time.sleep(1)
+            responsive_sleep(self, 1)
             if int(time.time()) % 30 == 0:
                 self.screen_print(f"{pendulum.from_timestamp(int(time.time()))}")
                 self.screen_print(f"{self.next_5_cron_s - int(time.time())} seconds till status")

--- a/gw_spaceheat/actors/scada_base.py
+++ b/gw_spaceheat/actors/scada_base.py
@@ -1,4 +1,3 @@
-import threading
 import uuid
 from abc import abstractmethod
 
@@ -27,8 +26,6 @@ class ScadaBase(ActorBase):
         self.gw_publish_client.on_connect = self.on_gw_publish_connect
         self.gw_publish_client.on_connect_fail = self.on_gw_publish_connect_fail
         self.gw_publish_client.on_disconnect = self.on_gw_publish_disconnect
-        self.gw_publish_client.connect(self.gwMqttBroker)
-        self.gw_publish_client.loop_start()
         if self.logging_on:
             self.gw_publish_client.on_log = self.on_log
         self.gw_consume_client_id = "-".join(str(uuid.uuid4()).split("-")[:-1])
@@ -40,12 +37,15 @@ class ScadaBase(ActorBase):
         self.gw_consume_client.on_connect = self.on_gw_consume_connect
         self.gw_consume_client.on_connect_fail = self.on_gw_consume_connect_fail
         self.gw_consume_client.on_disconnect = self.on_gw_consume_disconnect
-        self.gw_consume_client.connect(self.gwMqttBroker)
         if self.logging_on:
             self.gw_consume_client.on_log = self.on_log
+
+
+    def subscribe_gw_consume_client(self):
         self.gw_consume_client.subscribe(
             list(map(lambda x: (f"{x.Topic}", x.Qos.value), self.gw_subscriptions()))
         )
+
 
     @abstractmethod
     def gw_subscriptions(self):
@@ -79,6 +79,8 @@ class ScadaBase(ActorBase):
                 f"({helpers.log_time()}) GW Consume Connected flags {str(flags)} + result code {str(rc)}"
             ]
         )
+        self.subscribe_gw_consume_client()
+
 
     # noinspection PyUnusedLocal
     def on_gw_consume_connect_fail(self, client, userdata, rc):
@@ -123,20 +125,13 @@ class ScadaBase(ActorBase):
         )
 
     def start(self):
-        self.publish_client.loop_start()
-        self.consume_client.loop_start()
-        self.gw_consume_client.loop_start()
-        self.gw_publish_client.loop_start()
-        self.main_thread = threading.Thread(target=self.main)
-        self.main_thread.start()
+        super().start()
+        self.gw_publish_client.connect(self.gwMqttBroker)
+        self.gw_consume_client.connect(self.gwMqttBroker)
         self.screen_print(f"Started {self.__class__}")
 
     def stop(self):
-        self.screen_print("Stopping ...")
-        self.consume_client.loop_stop()
+        super().stop()
         self.gw_consume_client.loop_stop()
-        self.terminate_main_loop()
-        self.main_thread.join()
-        self.publish_client.loop_stop()
         self.gw_publish_client.loop_stop()
-        self.screen_print("Stopped")
+        self.screen_print(f"Stopped {self.__class__}")

--- a/gw_spaceheat/actors/scada_base.py
+++ b/gw_spaceheat/actors/scada_base.py
@@ -40,12 +40,10 @@ class ScadaBase(ActorBase):
         if self.logging_on:
             self.gw_consume_client.on_log = self.on_log
 
-
     def subscribe_gw_consume_client(self):
         self.gw_consume_client.subscribe(
             list(map(lambda x: (f"{x.Topic}", x.Qos.value), self.gw_subscriptions()))
         )
-
 
     @abstractmethod
     def gw_subscriptions(self):
@@ -81,8 +79,8 @@ class ScadaBase(ActorBase):
         )
         self.subscribe_gw_consume_client()
 
-
     # noinspection PyUnusedLocal
+
     def on_gw_consume_connect_fail(self, client, userdata, rc):
         self.mqtt_log_hack(
             [f"({helpers.log_time()}) GW Consume Connect fail! result code {str(rc)}"]

--- a/gw_spaceheat/actors/simple_sensor.py
+++ b/gw_spaceheat/actors/simple_sensor.py
@@ -6,7 +6,7 @@ from data_classes.sh_node import ShNode
 from schema.gt.gt_telemetry.gt_telemetry_maker import GtTelemetry_Maker
 
 from actors.actor_base import ActorBase
-from actors.utils import Subscription
+from actors.utils import Subscription, responsive_sleep
 
 
 class SimpleSensor(ActorBase):
@@ -51,7 +51,7 @@ class SimpleSensor(ActorBase):
         if (time_of_read_s - check_start_s) > self.MAIN_LOOP_MIN_TIME_S:
             return
         wait_time_s = self.MAIN_LOOP_MIN_TIME_S - (time_of_read_s - check_start_s)
-        time.sleep(wait_time_s)
+        responsive_sleep(self, wait_time_s)
 
     def main(self):
         self._main_loop_running = True

--- a/gw_spaceheat/actors/utils.py
+++ b/gw_spaceheat/actors/utils.py
@@ -1,4 +1,5 @@
 import enum
+import time
 from typing import NamedTuple
 
 
@@ -11,3 +12,24 @@ class QOS(enum.Enum):
 class Subscription(NamedTuple):
     Topic: str
     Qos: QOS
+
+DEFAULT_STEP_DURATION = .1
+def responsive_sleep(
+        obj,
+        seconds:float,
+        step_duration:float = DEFAULT_STEP_DURATION,
+        running_field_name: str = "_main_loop_running"
+) -> bool:
+    """Sleep in way that is more responsive to thread termination: sleep in step_duration increments up to
+    specificed seconds, at after each step checking self._main_loop_running"""
+    sleeps = int(seconds / step_duration)
+    if sleeps * step_duration != seconds:
+        last_sleep = seconds - (sleeps * step_duration)
+    else:
+        last_sleep = 0
+    for _ in range(sleeps):
+        if getattr(obj, running_field_name):
+            time.sleep(step_duration)
+    if getattr(obj, running_field_name) and last_sleep > 0:
+        time.sleep(last_sleep)
+    return getattr(obj, running_field_name)

--- a/gw_spaceheat/actors/utils.py
+++ b/gw_spaceheat/actors/utils.py
@@ -13,11 +13,14 @@ class Subscription(NamedTuple):
     Topic: str
     Qos: QOS
 
+
 DEFAULT_STEP_DURATION = .1
+
+
 def responsive_sleep(
         obj,
-        seconds:float,
-        step_duration:float = DEFAULT_STEP_DURATION,
+        seconds: float,
+        step_duration: float = DEFAULT_STEP_DURATION,
         running_field_name: str = "_main_loop_running"
 ) -> bool:
     """Sleep in way that is more responsive to thread termination: sleep in step_duration increments up to

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -10,7 +10,6 @@ from schema.gs.gs_dispatch import GsDispatch
 import schema.property_format
 import settings
 from actors.atn import Atn
-from actors.boolean_actuator import BooleanActuator
 from actors.cloud_ear import CloudEar
 from actors.power_meter import PowerMeter
 from actors.scada import Scada
@@ -162,12 +161,12 @@ def test_temp_sensor_loop_time():
     )
     for node in tank_water_temp_sensor_nodes:
         sensor = SimpleSensor(node)
+        sensor._main_loop_running = True
         start = time.time()
         sensor.check_and_report_temp()
         end = time.time()
         loop_ms = 1000 * (end - start)
         assert loop_ms > 200
-    time.sleep(2)
 
 
 def test_async_power_metering_dag():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -18,10 +18,11 @@ class StopWatch(object):
         self.end = time.time()
         self.elapsed = self.end - self.start
 
+
 class StopMe:
     def __init__(
             self, running: bool = True,
-            step_duration:float = .1
+            step_duration: float = .1
     ):
         self.running = running
         self.step_duration = step_duration
@@ -46,6 +47,7 @@ class StopMe:
 
 
 MAX_DELAY = .01
+
 
 def test_responsive_sleep():
     sw = StopWatch()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,68 @@
+import threading
+import time
+
+from actors.utils import responsive_sleep
+
+
+class StopWatch(object):
+    """Measure time with context manager"""
+
+    start: float = 0
+    end: float = 0
+    elapsed: float = 0
+
+    def __enter__(self):
+        self.start = time.time()
+
+    def __exit__(self, type_, value, traceback):
+        self.end = time.time()
+        self.elapsed = self.end - self.start
+
+class StopMe:
+    def __init__(
+            self, running: bool = True,
+            step_duration:float = .1
+    ):
+        self.running = running
+        self.step_duration = step_duration
+        self.thread = threading.Thread(target=self.loop)
+
+    def loop(self):
+        while self.running:
+            print(".")
+            responsive_sleep(
+                self,
+                1.0,
+                step_duration=self.step_duration,
+                running_field_name="running"
+            )
+
+    def start(self):
+        self.thread.start()
+
+    def stop(self):
+        self.running = False
+        self.thread.join()
+
+
+MAX_DELAY = .01
+
+def test_responsive_sleep():
+    sw = StopWatch()
+    seconds = .1
+    with sw:
+        responsive_sleep(StopMe(), seconds, running_field_name="running")
+    assert seconds <= sw.elapsed < seconds + MAX_DELAY
+    seconds = .01
+    with sw:
+        responsive_sleep(StopMe(), seconds, running_field_name="running")
+    assert seconds <= sw.elapsed < seconds + MAX_DELAY
+    with sw:
+        responsive_sleep(StopMe(running=False), seconds, running_field_name="running")
+    assert 0 <= sw.elapsed < MAX_DELAY
+    step_duration = .1
+    stop_me = StopMe(step_duration=step_duration)
+    stop_me.start()
+    with sw:
+        stop_me.stop()
+    assert 0 <= sw.elapsed < step_duration + MAX_DELAY


### PR DESCRIPTION
* calls to MQTTClient.connect() moved to out of `__init__()` routines and into start() routines.
* MQTTClient.disconnect() called before stopping MQTT loop for more controlled behavior.
* time.sleep() calls replaced with responsive_sleep() calls so that when actors are shut down their
  threads terminate promptly.