### PR TITLE
Jm/remove ear. WARNING: requires update to settings.py

### DIFF
--- a/DerivationTools/Scada/SSoT/Airtable.xml
+++ b/DerivationTools/Scada/SSoT/Airtable.xml
@@ -872,6 +872,13 @@
       <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>rec0FukmU8ALivkym</SchemaAttributeId>
+      <createdTime>2022-07-05T12:42:51Z</createdTime>
+      <TypeCheck>0</TypeCheck>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>rec0SCL5wm4k2QtCO</SchemaAttributeId>
       <createdTime>2022-07-03T22:29:19Z</createdTime>
       <Value>ValueList</Value>
@@ -993,6 +1000,22 @@
       <PrimitiveFormatFail1>1656245000</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>rec2NckVsy3wDPK6Q</SchemaAttributeId>
+      <createdTime>2022-07-05T12:56:22Z</createdTime>
+      <Value>FromGNodeAlias</Value>
+      <GtSchema>recjI10N2qf36kpmC</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>recb9fI4kRkTYXDzA</PrimitiveFormatId>
+      <TestValue>"dwtest.isone.ct.newhaven.orange1.ta.scada"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>LrdAliasFormat</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>rec2k6vwhh6cSgwse</SchemaAttributeId>
       <createdTime>2022-06-04T19:11:07Z</createdTime>
       <Value>ComponentAttributeClassId</Value>
@@ -1062,6 +1085,13 @@
       <PrimitiveType>Boolean</PrimitiveType>
       <TestValue>True</TestValue>
       <TypeCheck>1</TypeCheck>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>rec4vvtyR6uR3t2lj</SchemaAttributeId>
+      <createdTime>2022-07-05T12:56:09Z</createdTime>
+      <TypeCheck>0</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>false</IsType>
     </SchemaAttribute>
@@ -1247,6 +1277,22 @@
       <IsType>false</IsType>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>recABBs8u89Tj3Iu2</SchemaAttributeId>
+      <createdTime>2022-07-05T12:50:15Z</createdTime>
+      <Value>SlotStartUnixS</Value>
+      <GtSchema>recbbx6wGZEfqP2Kn</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>Integer</PrimitiveType>
+      <PrimitiveFormatId>rec13dujLuXXSf5L3</PrimitiveFormatId>
+      <TestValue>1656945300</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>ReasonableUnixTimeS</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>32503683600</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>recAHDR5VnUrRann9</SchemaAttributeId>
       <createdTime>2022-07-03T22:36:14Z</createdTime>
       <Value>ShNodeAlias</Value>
@@ -1292,6 +1338,20 @@
       <SubTypeDataClass>TempSensorComponent</SubTypeDataClass>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>recBtrSRyxjOXp8aA</SchemaAttributeId>
+      <createdTime>2022-07-05T12:50:17Z</createdTime>
+      <Value>SimpleTelemetryList</Value>
+      <GtSchema>recbbx6wGZEfqP2Kn</GtSchema>
+      <SubTypeFormat>recwcEF6jm0pivW8K</SubTypeFormat>
+      <IsRequired>true</IsRequired>
+      <IsList>true</IsList>
+      <TestValue> [{"ValueList": [0, 1], "ReadTimeUnixMsList": [1656945400527, 1656945414270], "ShNodeAlias": "a.elt1.relay", "TypeAlias": "gt.sh.simple.telemetry.status.100", "TelemetryNameGtEnumSymbol": "5a71d4b3"}]</TestValue>
+      <SubMessageFormatAlias>gt.sh.simple.telemetry.status</SubMessageFormatAlias>
+      <TypeCheck>1</TypeCheck>
+      <IsEnum>false</IsEnum>
+      <IsType>true</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>recBvZfLA3CxARt9t</SchemaAttributeId>
       <createdTime>2022-06-07T09:32:21Z</createdTime>
       <Value>DisplayName</Value>
@@ -1302,6 +1362,22 @@
       <TypeCheck>1</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recCyeOy0hRRYAvoc</SchemaAttributeId>
+      <createdTime>2022-07-05T12:57:13Z</createdTime>
+      <Value>FromGNodeId</Value>
+      <GtSchema>recjI10N2qf36kpmC</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>rec24qjC90m0f4Kvl</PrimitiveFormatId>
+      <TestValue>"0384ef21-648b-4455-b917-58a1172d7fc1"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>UuidCanonicalTextual</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"d4be12d5-33ba-4f1f-b9e5"</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recD4VpikwJAaTf0c</SchemaAttributeId>
@@ -1319,6 +1395,22 @@
       <IsEnum>false</IsEnum>
       <IsType>false</IsType>
       <PrimitiveFormatFail1>"d4be12d5-33ba-4f1f-b9e5"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recDMDjJ0WR1xxx1F</SchemaAttributeId>
+      <createdTime>2022-07-05T12:42:57Z</createdTime>
+      <Value>SendTimeUnixMs</Value>
+      <GtSchema>recoAsAg06Qp7jYp3</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>Integer</PrimitiveType>
+      <PrimitiveFormatId>recqSXVzLo8RtEjlH</PrimitiveFormatId>
+      <TestValue>1657025211851</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>ReasonableUnixTimeMs</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>1656245000</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recDqlTLtxwH7MceZ</SchemaAttributeId>
@@ -1339,11 +1431,11 @@
       <SubTypeFormat>recNH5aI7c5Latl1K</SubTypeFormat>
       <IsRequired>true</IsRequired>
       <IsList>true</IsList>
+      <TestValue> [{"ShNodeAlias": "a.elt1.relay","RelayStateCommandList": [1], "CommandTimeUnixMsList": [1656945413464],"TypeAlias": "gt.sh.booleanactuator.cmd.status.100"}]</TestValue>
       <SubMessageFormatAlias>gt.sh.booleanactuator.cmd.status</SubMessageFormatAlias>
       <TypeCheck>1</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>true</IsType>
-      <TestValue> [{"ShNodeAlias": "a.elt1.relay","RelayStateCommandList": [1], "CommandTimeUnixMsList": [1656945413464],"TypeAlias": "gt.sh.booleanactuator.cmd.status.100"}]</TestValue>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recE3gvDLm8Zvz5AD</SchemaAttributeId>
@@ -1416,6 +1508,22 @@
       <IsType>false</IsType>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>recEnND4VVh74Ayni</SchemaAttributeId>
+      <createdTime>2022-07-05T12:50:08Z</createdTime>
+      <Value>AboutGNodeAlias</Value>
+      <GtSchema>recbbx6wGZEfqP2Kn</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>recb9fI4kRkTYXDzA</PrimitiveFormatId>
+      <TestValue>"dwtest.isone.ct.newhaven.orange1.ta"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>LrdAliasFormat</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>recEnxacHBN9FC6GG</SchemaAttributeId>
       <createdTime>2022-06-07T09:32:04Z</createdTime>
       <Value>ComponentId</Value>
@@ -1459,6 +1567,22 @@
       <EnumRoot>spaceheat.unit</EnumRoot>
       <IsEnum>true</IsEnum>
       <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recFUjvwvmvvkA01e</SchemaAttributeId>
+      <createdTime>2022-07-05T12:56:04Z</createdTime>
+      <Value>FromGNodeAlias</Value>
+      <GtSchema>receVdNEfIE1HLnwN</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>recb9fI4kRkTYXDzA</PrimitiveFormatId>
+      <TestValue>"dwtest.isone.ct.newhaven.orange1"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>LrdAliasFormat</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recFfaru1gmnzHcg3</SchemaAttributeId>
@@ -1622,6 +1746,20 @@
       <IsType>false</IsType>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>recJSFsEahEgbS5C2</SchemaAttributeId>
+      <createdTime>2022-07-05T12:50:27Z</createdTime>
+      <Value>BooleanactuatorCmdList</Value>
+      <GtSchema>recbbx6wGZEfqP2Kn</GtSchema>
+      <SubTypeFormat>recNH5aI7c5Latl1K</SubTypeFormat>
+      <IsRequired>true</IsRequired>
+      <IsList>true</IsList>
+      <TestValue> [{"ShNodeAlias": "a.elt1.relay","RelayStateCommandList": [1], "CommandTimeUnixMsList": [1656945413464],"TypeAlias": "gt.sh.booleanactuator.cmd.status.100"}]</TestValue>
+      <SubMessageFormatAlias>gt.sh.booleanactuator.cmd.status</SubMessageFormatAlias>
+      <TypeCheck>1</TypeCheck>
+      <IsEnum>false</IsEnum>
+      <IsType>true</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>recJW4Tmdi1HStfwy</SchemaAttributeId>
       <createdTime>2022-06-23T18:40:36Z</createdTime>
       <Value>AsyncReportThreshold</Value>
@@ -1632,6 +1770,22 @@
       <TypeCheck>1</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recJsAmOvRrHuzY0o</SchemaAttributeId>
+      <createdTime>2022-07-05T12:48:34Z</createdTime>
+      <Value>FromGNodeAlias</Value>
+      <GtSchema>recbbx6wGZEfqP2Kn</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>recb9fI4kRkTYXDzA</PrimitiveFormatId>
+      <TestValue>"dwtest.isone.ct.newhaven.orange1.ta.scada"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>LrdAliasFormat</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recK1YHQ9c8LbBJ0q</SchemaAttributeId>
@@ -1648,6 +1802,20 @@
       <IsEnum>false</IsEnum>
       <IsType>false</IsType>
       <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recK2zOa4WxMEeSn9</SchemaAttributeId>
+      <createdTime>2022-07-05T12:50:21Z</createdTime>
+      <Value>MultipurposeTelemetryList</Value>
+      <GtSchema>recbbx6wGZEfqP2Kn</GtSchema>
+      <SubTypeFormat>recCGkiwasshpUQnL</SubTypeFormat>
+      <IsRequired>true</IsRequired>
+      <IsList>true</IsList>
+      <TestValue> [{"AboutNodeAlias": "a.elt1", "ValueList": [18000], "ReadTimeUnixMsList": [1656945390152], "SensorNodeAlias": "a.m", "TypeAlias": "gt.sh.multipurpose.telemetry.status.100", "TelemetryNameGtEnumSymbol": "ad19e79c"}]</TestValue>
+      <SubMessageFormatAlias>gt.sh.multipurpose.telemetry.status</SubMessageFormatAlias>
+      <TypeCheck>1</TypeCheck>
+      <IsEnum>false</IsEnum>
+      <IsType>true</IsType>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recKwPBxJr8R55KlB</SchemaAttributeId>
@@ -1829,6 +1997,35 @@
       <PrimitiveFormatFail1>"d4be12d5-33ba-4f1f-b9e5"</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>recNpHoc7bhC32M0w</SchemaAttributeId>
+      <createdTime>2022-07-05T12:44:11Z</createdTime>
+      <Value>FromNodeAlias</Value>
+      <GtSchema>recoAsAg06Qp7jYp3</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>recb9fI4kRkTYXDzA</PrimitiveFormatId>
+      <TestValue>"a.s"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>LrdAliasFormat</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recO5REMzzyrc2uHT</SchemaAttributeId>
+      <createdTime>2022-07-05T12:55:53Z</createdTime>
+      <Value>SendSnapshot</Value>
+      <GtSchema>receVdNEfIE1HLnwN</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>Boolean</PrimitiveType>
+      <TestValue>True</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>recOWeL6PoLldCrop</SchemaAttributeId>
       <createdTime>2022-07-03T22:10:56Z</createdTime>
       <Value>SimpleTelemetryList</Value>
@@ -1836,11 +2033,11 @@
       <SubTypeFormat>recwcEF6jm0pivW8K</SubTypeFormat>
       <IsRequired>true</IsRequired>
       <IsList>true</IsList>
+      <TestValue> [{"ValueList": [0, 1], "ReadTimeUnixMsList": [1656945400527, 1656945414270], "ShNodeAlias": "a.elt1.relay", "TypeAlias": "gt.sh.simple.telemetry.status.100", "TelemetryNameGtEnumSymbol": "5a71d4b3"}]</TestValue>
       <SubMessageFormatAlias>gt.sh.simple.telemetry.status</SubMessageFormatAlias>
       <TypeCheck>1</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>true</IsType>
-      <TestValue> [{"ValueList": [0, 1], "ReadTimeUnixMsList": [1656945400527, 1656945414270], "ShNodeAlias": "a.elt1.relay", "TypeAlias": "gt.sh.simple.telemetry.status.100", "TelemetryNameGtEnumSymbol": "5a71d4b3"}]</TestValue>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recP1RBCr64M0yHV5</SchemaAttributeId>
@@ -1957,6 +2154,22 @@
       <IsType>false</IsType>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>recSNRAurDrIeUgqg</SchemaAttributeId>
+      <createdTime>2022-07-05T13:23:56Z</createdTime>
+      <TypeCheck>1</TypeCheck>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <Value>AboutNodeAlias</Value>
+      <GtSchema>rechZBY0G1JuNeEuG</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <TestValue>"a.elt1.relay"</TestValue>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>recb9fI4kRkTYXDzA</PrimitiveFormatId>
+      <PrimitiveFormat>LrdAliasFormat</PrimitiveFormat>
+      <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>recSUuF57hzqwp3RB</SchemaAttributeId>
       <createdTime>2022-05-12T01:42:26Z</createdTime>
       <Value>SlotStartUnixS</Value>
@@ -1991,6 +2204,7 @@
       <IsEnum>true</IsEnum>
       <IsType>false</IsType>
     </SchemaAttribute>
+    <SchemaAttribute>itrmIfpzjL1sROyEF/recThSkVs5p5LvmOD</SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recULYzX6MQbnGbeu</SchemaAttributeId>
       <createdTime>2022-06-14T10:51:44Z</createdTime>
@@ -2037,6 +2251,22 @@
       <PrimitiveFormatFail1>"d4be12d5-33ba-4f1f-b9e5"</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>recUyndqnwyKAWe93</SchemaAttributeId>
+      <createdTime>2022-07-05T12:45:01Z</createdTime>
+      <Value>ToGNodeAlias</Value>
+      <GtSchema>rechZBY0G1JuNeEuG</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>recb9fI4kRkTYXDzA</PrimitiveFormatId>
+      <TestValue>"dwtest.isone.ct.newhaven.orange1.ta.scada"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>LrdAliasFormat</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>recVWEvca4HtIB3MX</SchemaAttributeId>
       <createdTime>2022-07-03T21:26:55Z</createdTime>
       <TypeCheck>0</TypeCheck>
@@ -2054,6 +2284,22 @@
       <TypeCheck>1</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recVgR5ZOHi7dvBav</SchemaAttributeId>
+      <createdTime>2022-07-05T12:49:46Z</createdTime>
+      <Value>FromGNodeId</Value>
+      <GtSchema>recbbx6wGZEfqP2Kn</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>rec24qjC90m0f4Kvl</PrimitiveFormatId>
+      <TestValue>"0384ef21-648b-4455-b917-58a1172d7fc1"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>UuidCanonicalTextual</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"d4be12d5-33ba-4f1f-b9e5"</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recVqNOAao22ob4jS</SchemaAttributeId>
@@ -2128,6 +2374,22 @@
       <IsType>false</IsType>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>recWSgdPQdB9dVyux</SchemaAttributeId>
+      <createdTime>2022-07-05T12:42:52Z</createdTime>
+      <Value>AboutNodeAlias</Value>
+      <GtSchema>recoAsAg06Qp7jYp3</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>recb9fI4kRkTYXDzA</PrimitiveFormatId>
+      <TestValue>"a.elt1.relay"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>LrdAliasFormat</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>recXEIMX0kmlJ7eWH</SchemaAttributeId>
       <createdTime>2022-06-10T16:07:37Z</createdTime>
       <Value>DisplayName</Value>
@@ -2187,16 +2449,22 @@
       <SubTypeFormat>recCGkiwasshpUQnL</SubTypeFormat>
       <IsRequired>true</IsRequired>
       <IsList>true</IsList>
+      <TestValue> [{"AboutNodeAlias": "a.elt1", "ValueList": [18000], "ReadTimeUnixMsList": [1656945390152], "SensorNodeAlias": "a.m", "TypeAlias": "gt.sh.multipurpose.telemetry.status.100", "TelemetryNameGtEnumSymbol": "ad19e79c"}]</TestValue>
       <SubMessageFormatAlias>gt.sh.multipurpose.telemetry.status</SubMessageFormatAlias>
       <TypeCheck>1</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>true</IsType>
-      <TestValue> [{"AboutNodeAlias": "a.elt1", "ValueList": [18000], "ReadTimeUnixMsList": [1656945390152], "SensorNodeAlias": "a.m", "TypeAlias": "gt.sh.multipurpose.telemetry.status.100", "TelemetryNameGtEnumSymbol": "ad19e79c"}]</TestValue>
     </SchemaAttribute>
-    <SchemaAttribute>itrmwlCtE2Im3tOJ3/recZOVb1cq9Dq3Oi5</SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recZSLryoaKbh719a</SchemaAttributeId>
       <createdTime>2022-06-24T16:25:58Z</createdTime>
+      <TypeCheck>0</TypeCheck>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recaIsIQc9y1e22RN</SchemaAttributeId>
+      <createdTime>2022-07-05T12:42:22Z</createdTime>
       <TypeCheck>0</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>false</IsType>
@@ -2279,6 +2547,38 @@
       <IsType>true</IsType>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>recc61I5CYPBiSoz2</SchemaAttributeId>
+      <createdTime>2022-07-05T11:33:09Z</createdTime>
+      <Value>FromGNodeAlias</Value>
+      <GtSchema>rechZBY0G1JuNeEuG</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>recb9fI4kRkTYXDzA</PrimitiveFormatId>
+      <TestValue>"dwtest.isone.ct.newhaven.orange1"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>LrdAliasFormat</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"a.b-h"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>reccHAZq7xruWVLSo</SchemaAttributeId>
+      <createdTime>2022-07-05T11:34:01Z</createdTime>
+      <Value>FromGNodeId</Value>
+      <GtSchema>rechZBY0G1JuNeEuG</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>rec24qjC90m0f4Kvl</PrimitiveFormatId>
+      <TestValue>"e7f7d6cc-08b0-4b36-bbbb-0a1f8447fd32"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>UuidCanonicalTextual</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"d4be12d5-33ba-4f1f-b9e5"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>reccTfzFazDviUeXp</SchemaAttributeId>
       <createdTime>2022-05-12T01:49:05Z</createdTime>
       <Value>AccuracyCategory</Value>
@@ -2338,6 +2638,22 @@
       <TypeCheck>1</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recdwjoLr6DQUc20I</SchemaAttributeId>
+      <createdTime>2022-07-05T12:48:10Z</createdTime>
+      <Value>StatusUid</Value>
+      <GtSchema>recbbx6wGZEfqP2Kn</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>rec24qjC90m0f4Kvl</PrimitiveFormatId>
+      <TestValue>"dedc25c2-8276-4b25-abd6-f53edc79b62b"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>UuidCanonicalTextual</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"d4be12d5-33ba-4f1f-b9e5"</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>rece76qbENBm5shvn</SchemaAttributeId>
@@ -2496,6 +2812,22 @@
       <SubTypeDataClass>ThermalEdge</SubTypeDataClass>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>reci0niurz5s0wuXJ</SchemaAttributeId>
+      <createdTime>2022-07-05T12:56:10Z</createdTime>
+      <Value>FromGNodeId</Value>
+      <GtSchema>receVdNEfIE1HLnwN</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>String</PrimitiveType>
+      <PrimitiveFormatId>rec24qjC90m0f4Kvl</PrimitiveFormatId>
+      <TestValue>"e7f7d6cc-08b0-4b36-bbbb-0a1f8447fd32"</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>UuidCanonicalTextual</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>"d4be12d5-33ba-4f1f-b9e5"</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>reci7Ga0o0Ubtlk5g</SchemaAttributeId>
       <createdTime>2022-06-06T18:45:58Z</createdTime>
       <Value>HwUid</Value>
@@ -2579,6 +2911,35 @@
       <TypeCheck>1</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recjPLNQVJ2uCOYfC</SchemaAttributeId>
+      <createdTime>2022-07-05T11:33:12Z</createdTime>
+      <Value>RelayState</Value>
+      <GtSchema>rechZBY0G1JuNeEuG</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>Integer</PrimitiveType>
+      <PrimitiveFormatId>recLyqFB0L7XFIp6C</PrimitiveFormatId>
+      <TestValue>0</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>Bit</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>2</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recjXMbjBpdJFTXBi</SchemaAttributeId>
+      <createdTime>2022-07-05T12:57:11Z</createdTime>
+      <Value>Snapshot</Value>
+      <GtSchema>recjI10N2qf36kpmC</GtSchema>
+      <SubTypeFormat>recyuopIDguUgR1mI</SubTypeFormat>
+      <IsRequired>true</IsRequired>
+      <TestValue>{"TelemetryNameList": ["5a71d4b3"], "AboutNodeAliasList": ["a.elt1.relay"], "ReportTimeUnixMs": 1656363448000, "ValueList": [1], "TypeAlias": "gt.sh.status.snapshot.110"}</TestValue>
+      <SubMessageFormatAlias>gt.sh.status.snapshot</SubMessageFormatAlias>
+      <TypeCheck>1</TypeCheck>
+      <IsEnum>false</IsEnum>
+      <IsType>true</IsType>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recjdjO1e7eWo3j8T</SchemaAttributeId>
@@ -2833,6 +3194,22 @@
       <TypeCheck>1</TypeCheck>
       <IsEnum>false</IsEnum>
       <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
+      <SchemaAttributeId>recnqelpRWYmV8MJR</SchemaAttributeId>
+      <createdTime>2022-07-05T12:42:46Z</createdTime>
+      <Value>RelayState</Value>
+      <GtSchema>recoAsAg06Qp7jYp3</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>Integer</PrimitiveType>
+      <PrimitiveFormatId>recLyqFB0L7XFIp6C</PrimitiveFormatId>
+      <TestValue>1</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>Bit</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>2</PrimitiveFormatFail1>
     </SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>reco2D59kEGzC9zN3</SchemaAttributeId>
@@ -3112,6 +3489,19 @@
       <IsType>false</IsType>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>recuaEgD9IK8ftLcu</SchemaAttributeId>
+      <createdTime>2022-07-05T12:50:12Z</createdTime>
+      <Value>ReportingPeriodS</Value>
+      <GtSchema>recbbx6wGZEfqP2Kn</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>Integer</PrimitiveType>
+      <TestValue>300</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>recvu5jsnE4pgxC49</SchemaAttributeId>
       <createdTime>2022-06-20T11:30:02Z</createdTime>
       <Value>Alias</Value>
@@ -3175,6 +3565,7 @@
       <IsEnum>true</IsEnum>
       <IsType>false</IsType>
     </SchemaAttribute>
+    <SchemaAttribute>itrmIfpzjL1sROyEF/recxEGfMCfyl49hgk</SchemaAttribute>
     <SchemaAttribute>
       <SchemaAttributeId>recxu6lhNMYHCoQey</SchemaAttributeId>
       <createdTime>2022-06-14T10:59:26Z</createdTime>
@@ -3256,6 +3647,22 @@
       <IsType>false</IsType>
     </SchemaAttribute>
     <SchemaAttribute>
+      <SchemaAttributeId>reczfNmiB9hWAkSsY</SchemaAttributeId>
+      <createdTime>2022-07-05T11:33:06Z</createdTime>
+      <Value>SendTimeUnixMs</Value>
+      <GtSchema>rechZBY0G1JuNeEuG</GtSchema>
+      <IsRequired>true</IsRequired>
+      <IsPrimitive>true</IsPrimitive>
+      <PrimitiveType>Integer</PrimitiveType>
+      <PrimitiveFormatId>recqSXVzLo8RtEjlH</PrimitiveFormatId>
+      <TestValue>1657024737661</TestValue>
+      <TypeCheck>1</TypeCheck>
+      <PrimitiveFormat>ReasonableUnixTimeMs</PrimitiveFormat>
+      <IsEnum>false</IsEnum>
+      <IsType>false</IsType>
+      <PrimitiveFormatFail1>1656245000</PrimitiveFormatFail1>
+    </SchemaAttribute>
+    <SchemaAttribute>
       <SchemaAttributeId>reczovvHr0jpI0nE1</SchemaAttributeId>
       <createdTime>2022-06-14T23:03:03Z</createdTime>
       <Value>Role</Value>
@@ -3288,8 +3695,8 @@
       <Description>PollPeriodMs must be less than ReportingPeriodMs. PollPeriodMs is how frequently data is polled from the meter. ReportingPeriodMs is the synchronous report to the scada.</Description>
       <SchemaId>recUrIRjO9EYJRQhG</SchemaId>
       <LocalName>PollMoreThanReporting</LocalName>
-      <SchemaAlias>gt.powermeter.reporting.config.100</SchemaAlias>
       <Name>gt.powermeter.reporting.config.100__PollMoreThanReporting</Name>
+      <SchemaAlias>gt.powermeter.reporting.config.100</SchemaAlias>
     </SchemaAxiom>
     <SchemaAxiom>
       <SchemaAxiomId>recsymqeqSBbr9R9o</SchemaAxiomId>
@@ -3297,8 +3704,8 @@
       <Description>TelemetryNameList, AboutNodeList, ValueList must all be lists of the same length</Description>
       <SchemaId>recyuopIDguUgR1mI</SchemaId>
       <LocalName>ListLengthConsistency</LocalName>
-      <SchemaAlias>gt.sh.status.snapshot.110</SchemaAlias>
       <Name>gt.sh.status.snapshot.110__ListLengthConsistency</Name>
+      <SchemaAlias>gt.sh.status.snapshot.110</SchemaAlias>
     </SchemaAxiom>
   </SchemaAxioms>
   <PropertyFormats>
@@ -3308,6 +3715,7 @@
       <Name>ReasonableUnixTimeS</Name>
       <Description>Integer reflecting unix time seconds between 1970 and 3000</Description>
       <MpSchemaAttributes>reccl6zfh9EN32iFD</MpSchemaAttributes>
+      <MpSchemaAttributes>recABBs8u89Tj3Iu2</MpSchemaAttributes>
       <DefaultFail1>32503683600</DefaultFail1>
     </PropertyFormat>
     <PropertyFormat>
@@ -3328,6 +3736,11 @@
       <MpSchemaAttributes>rec9jK6ONtXBpXevt</MpSchemaAttributes>
       <MpSchemaAttributes>recmAJ31xoOq5qTHU</MpSchemaAttributes>
       <MpSchemaAttributes>recoBjlyHgao1lKtI</MpSchemaAttributes>
+      <MpSchemaAttributes>reccHAZq7xruWVLSo</MpSchemaAttributes>
+      <MpSchemaAttributes>recdwjoLr6DQUc20I</MpSchemaAttributes>
+      <MpSchemaAttributes>recVgR5ZOHi7dvBav</MpSchemaAttributes>
+      <MpSchemaAttributes>reci0niurz5s0wuXJ</MpSchemaAttributes>
+      <MpSchemaAttributes>recCyeOy0hRRYAvoc</MpSchemaAttributes>
       <DefaultFail1>"d4be12d5-33ba-4f1f-b9e5"</DefaultFail1>
     </PropertyFormat>
     <PropertyFormat>
@@ -3339,6 +3752,8 @@
       <MpSchemaAttributes>reciVyeMslNHUJKN8</MpSchemaAttributes>
       <MpSchemaAttributes>rech7EAFuj56GsPDR</MpSchemaAttributes>
       <MpSchemaAttributes>recNIuEg4dFDhi9Yn</MpSchemaAttributes>
+      <MpSchemaAttributes>recjPLNQVJ2uCOYfC</MpSchemaAttributes>
+      <MpSchemaAttributes>recnqelpRWYmV8MJR</MpSchemaAttributes>
       <DefaultFail1>2</DefaultFail1>
     </PropertyFormat>
     <PropertyFormat>
@@ -3361,6 +3776,15 @@
       <MpSchemaAttributes>rec2l6jE1FMj92czA</MpSchemaAttributes>
       <MpSchemaAttributes>recAHDR5VnUrRann9</MpSchemaAttributes>
       <MpSchemaAttributes>recfnCI6bJWG4n4xR</MpSchemaAttributes>
+      <MpSchemaAttributes>recc61I5CYPBiSoz2</MpSchemaAttributes>
+      <MpSchemaAttributes>recUyndqnwyKAWe93</MpSchemaAttributes>
+      <MpSchemaAttributes>recWSgdPQdB9dVyux</MpSchemaAttributes>
+      <MpSchemaAttributes>recNpHoc7bhC32M0w</MpSchemaAttributes>
+      <MpSchemaAttributes>recEnND4VVh74Ayni</MpSchemaAttributes>
+      <MpSchemaAttributes>recJsAmOvRrHuzY0o</MpSchemaAttributes>
+      <MpSchemaAttributes>recFUjvwvmvvkA01e</MpSchemaAttributes>
+      <MpSchemaAttributes>rec2NckVsy3wDPK6Q</MpSchemaAttributes>
+      <MpSchemaAttributes>recSNRAurDrIeUgqg</MpSchemaAttributes>
       <DefaultFail1>"a.b-h"</DefaultFail1>
     </PropertyFormat>
     <PropertyFormat>
@@ -3385,6 +3809,8 @@
       <MpSchemaAttributes>recgVLpaOczJX5BCi</MpSchemaAttributes>
       <MpSchemaAttributes>recqQXSGmEMh3lnTf</MpSchemaAttributes>
       <MpSchemaAttributes>recPF2sGh74G7KL7C</MpSchemaAttributes>
+      <MpSchemaAttributes>reczfNmiB9hWAkSsY</MpSchemaAttributes>
+      <MpSchemaAttributes>recDMDjJ0WR1xxx1F</MpSchemaAttributes>
       <DefaultFail1>1656245000</DefaultFail1>
     </PropertyFormat>
     <PropertyFormat>
@@ -3412,8 +3838,8 @@
       <SchemaAttributes>recJ3u86m6sh2vNWk</SchemaAttributes>
       <UsedAsSubMessagein>recbw5AyGqRuPCnlj</UsedAsSubMessagein>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.eq.reporting.config.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>rec23C6am0WIH9veT</SchemaId>
@@ -3426,8 +3852,8 @@
       <SchemaAttributes>recmUBXrUigX4SFIe</SchemaAttributes>
       <SchemaAttributes>recqTlmb22FCbFzaQ</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.simple.status.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>rec4u5c6FO198haBK</SchemaId>
@@ -3444,8 +3870,8 @@
       <MakeDataClass>true</MakeDataClass>
       <DataClass>PipeFlowSensorComponent</DataClass>
       <IsComponent>true</IsComponent>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.pipe.flow.sensor.component.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>rec8CoTLGyxAXh6TD</SchemaId>
@@ -3462,8 +3888,8 @@
       <SemanticEnd>110</SemanticEnd>
       <MakeDataClass>true</MakeDataClass>
       <DataClass>ShNode</DataClass>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.node.110</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recAMM4MM8wzs10u8</SchemaId>
@@ -3480,19 +3906,19 @@
       <SemanticEnd>100</SemanticEnd>
       <MakeDataClass>true</MakeDataClass>
       <DataClass>ShNode</DataClass>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.node.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recAyAxneWaDdakQ6</SchemaId>
       <createdTime>2022-06-20T13:14:15Z</createdTime>
       <AliasRoot>gt.sh.cli.scada.response</AliasRoot>
-      <Status>Active</Status>
+      <Status>Deprecated</Status>
       <ProtocolType>Json</ProtocolType>
       <SchemaAttributes>recbRDhEoGNs9jYEB</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.cli.scada.response.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recCGkiwasshpUQnL</SchemaId>
@@ -3506,9 +3932,10 @@
       <SchemaAttributes>recqQXSGmEMh3lnTf</SchemaAttributes>
       <SchemaAttributes>rectMt3G7nhz2ujs5</SchemaAttributes>
       <UsedAsSubMessagein>recZOVb1cq9Dq3Oi5</UsedAsSubMessagein>
+      <UsedAsSubMessagein>recK2zOa4WxMEeSn9</UsedAsSubMessagein>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.multipurpose.telemetry.status.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recEdlcUTBfQ9Hy6D</SchemaId>
@@ -3525,8 +3952,8 @@
       <SemanticEnd>100</SemanticEnd>
       <MakeDataClass>true</MakeDataClass>
       <DataClass>Component</DataClass>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.component.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recHrNVLHcDTTqaCq</SchemaId>
@@ -3543,19 +3970,19 @@
       <MakeDataClass>true</MakeDataClass>
       <DataClass>TempSensorComponent</DataClass>
       <IsComponent>true</IsComponent>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.temp.sensor.component.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recK21HSqZTAjGvlG</SchemaId>
       <createdTime>2022-06-20T12:58:57Z</createdTime>
       <AliasRoot>gt.sh.cli.atn.cmd</AliasRoot>
-      <Status>Active</Status>
+      <Status>Deprecated</Status>
       <ProtocolType>Json</ProtocolType>
       <SchemaAttributes>recZ6Qnf2ivCfWkSG</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.cli.atn.cmd.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recK5H9Pt9ZpF6hgi</SchemaId>
@@ -3569,8 +3996,8 @@
       <SemanticEnd>100</SemanticEnd>
       <MakeDataClass>true</MakeDataClass>
       <DataClass>ComponentAttributeClass</DataClass>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.component.attribute.class.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recKVkCs5ktwXS3Bu</SchemaId>
@@ -3588,8 +4015,8 @@
       <MakeDataClass>true</MakeDataClass>
       <DataClass>PipeFlowSensorCac</DataClass>
       <IsCac>true</IsCac>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.pipe.flow.sensor.cac.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recLc7QnBdk9iPdHI</SchemaId>
@@ -3603,8 +4030,8 @@
       <SchemaAttributes>rec2ERXNwEH6jyyHv</SchemaAttributes>
       <UsedAsSubMessagein>recqTlmb22FCbFzaQ</UsedAsSubMessagein>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.simple.single.status.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recNH5aI7c5Latl1K</SchemaId>
@@ -3616,9 +4043,10 @@
       <SchemaAttributes>recNIuEg4dFDhi9Yn</SchemaAttributes>
       <SchemaAttributes>recPF2sGh74G7KL7C</SchemaAttributes>
       <UsedAsSubMessagein>recE2H3ffos4Ujqq7</UsedAsSubMessagein>
+      <UsedAsSubMessagein>recJSFsEahEgbS5C2</UsedAsSubMessagein>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.booleanactuator.cmd.status.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recT6312S7LckLHZ9</SchemaId>
@@ -3635,8 +4063,8 @@
       <MakeDataClass>true</MakeDataClass>
       <DataClass>ElectricHeaterComponent</DataClass>
       <IsComponent>true</IsComponent>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.electric.heater.component.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recUrIRjO9EYJRQhG</SchemaId>
@@ -3650,8 +4078,8 @@
       <SchemaAttributes>rec8i1VAK2sgrnBWW</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
       <SchemaAxioms>rec29eq9Lc6OGIhYk</SchemaAxioms>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.powermeter.reporting.config.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recVNiapT0HIufahj</SchemaId>
@@ -3660,14 +4088,33 @@
       <Status>Active</Status>
       <ProtocolType>Json</ProtocolType>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.heartbeat.a.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
+    </Schema>
+    <Schema>
+      <SchemaId>recbbx6wGZEfqP2Kn</SchemaId>
+      <createdTime>2022-07-05T12:48:52Z</createdTime>
+      <AliasRoot>gt.sh.status</AliasRoot>
+      <Status>Active</Status>
+      <ProtocolType>Json</ProtocolType>
+      <SchemaAttributes>recJsAmOvRrHuzY0o</SchemaAttributes>
+      <SchemaAttributes>recVgR5ZOHi7dvBav</SchemaAttributes>
+      <SchemaAttributes>recEnND4VVh74Ayni</SchemaAttributes>
+      <SchemaAttributes>recuaEgD9IK8ftLcu</SchemaAttributes>
+      <SchemaAttributes>recABBs8u89Tj3Iu2</SchemaAttributes>
+      <SchemaAttributes>recBtrSRyxjOXp8aA</SchemaAttributes>
+      <SchemaAttributes>recK2zOa4WxMEeSn9</SchemaAttributes>
+      <SchemaAttributes>recdwjoLr6DQUc20I</SchemaAttributes>
+      <SchemaAttributes>recJSFsEahEgbS5C2</SchemaAttributes>
+      <SemanticEnd>110</SemanticEnd>
+      <Alias>gt.sh.status.110</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recbeBI4t64CBVq2v</SchemaId>
       <createdTime>2022-07-03T22:09:49Z</createdTime>
       <AliasRoot>gt.sh.status</AliasRoot>
-      <Status>Active</Status>
+      <Status>Deprecated</Status>
       <ProtocolType>Json</ProtocolType>
       <SchemaAttributes>recfnCI6bJWG4n4xR</SchemaAttributes>
       <SchemaAttributes>recl1CjNX7CBI77Cf</SchemaAttributes>
@@ -3676,8 +4123,8 @@
       <SchemaAttributes>recZOVb1cq9Dq3Oi5</SchemaAttributes>
       <SchemaAttributes>recE2H3ffos4Ujqq7</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.status.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recc5qGcZNQPmktbe</SchemaId>
@@ -3688,8 +4135,8 @@
       <SchemaAttributes>recw4w4kyKb5qsTUd</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
       <SendAlias>p</SendAlias>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gs.pwr.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>reccc96DDf5Ue9FmA</SchemaId>
@@ -3709,8 +4156,8 @@
       <MakeDataClass>true</MakeDataClass>
       <DataClass>ElectricMeterCac</DataClass>
       <IsCac>true</IsCac>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.electric.meter.cac.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recdbl99ZoQqyOhS7</SchemaId>
@@ -3728,8 +4175,8 @@
       <MakeDataClass>true</MakeDataClass>
       <DataClass>BooleanActuatorComponent</DataClass>
       <IsComponent>true</IsComponent>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.boolean.actuator.component.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recdmZpmDC9qq3Wz5</SchemaId>
@@ -3741,8 +4188,8 @@
       <SchemaAttributes>rech7EAFuj56GsPDR</SchemaAttributes>
       <SchemaAttributes>recsyCaWjc5Ii5DrU</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.driver.booleanactuator.cmd.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>rece1suo3h3SqfW4M</SchemaId>
@@ -3759,8 +4206,21 @@
       <SchemaAttributes>recF5JRJR6AVkfQsK</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
       <DataClass>SensorReportingConfig</DataClass>
-      <ConsistencyCheck>0</ConsistencyCheck>
       <Alias>gt.sensor.reporting.config.100</Alias>
+      <ConsistencyCheck>0</ConsistencyCheck>
+    </Schema>
+    <Schema>
+      <SchemaId>receVdNEfIE1HLnwN</SchemaId>
+      <createdTime>2022-07-05T12:55:18Z</createdTime>
+      <AliasRoot>gt.sh.cli.atn.cmd</AliasRoot>
+      <Status>Active</Status>
+      <ProtocolType>Json</ProtocolType>
+      <SchemaAttributes>recO5REMzzyrc2uHT</SchemaAttributes>
+      <SchemaAttributes>recFUjvwvmvvkA01e</SchemaAttributes>
+      <SchemaAttributes>reci0niurz5s0wuXJ</SchemaAttributes>
+      <SemanticEnd>110</SemanticEnd>
+      <Alias>gt.sh.cli.atn.cmd.110</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>rechZ9OTpGxuT8xWl</SchemaId>
@@ -3777,8 +4237,37 @@
       <SchemaAttributes>reccTfzFazDviUeXp</SchemaAttributes>
       <SchemaAttributes>recn2CJw74mLLQ8tr</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.power.sync.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
+    </Schema>
+    <Schema>
+      <SchemaId>rechZBY0G1JuNeEuG</SchemaId>
+      <createdTime>2022-07-05T11:32:23Z</createdTime>
+      <AliasRoot>gt.dispatch.boolean</AliasRoot>
+      <Status>Active</Status>
+      <ProtocolType>Json</ProtocolType>
+      <SchemaAttributes>reczfNmiB9hWAkSsY</SchemaAttributes>
+      <SchemaAttributes>recjPLNQVJ2uCOYfC</SchemaAttributes>
+      <SchemaAttributes>recc61I5CYPBiSoz2</SchemaAttributes>
+      <SchemaAttributes>reccHAZq7xruWVLSo</SchemaAttributes>
+      <SchemaAttributes>recUyndqnwyKAWe93</SchemaAttributes>
+      <SchemaAttributes>recSNRAurDrIeUgqg</SchemaAttributes>
+      <SemanticEnd>100</SemanticEnd>
+      <Alias>gt.dispatch.boolean.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
+    </Schema>
+    <Schema>
+      <SchemaId>recjI10N2qf36kpmC</SchemaId>
+      <createdTime>2022-07-05T12:55:36Z</createdTime>
+      <AliasRoot>gt.sh.cli.scada.response</AliasRoot>
+      <Status>Active</Status>
+      <ProtocolType>Json</ProtocolType>
+      <SchemaAttributes>rec2NckVsy3wDPK6Q</SchemaAttributes>
+      <SchemaAttributes>recCyeOy0hRRYAvoc</SchemaAttributes>
+      <SchemaAttributes>recjXMbjBpdJFTXBi</SchemaAttributes>
+      <SemanticEnd>110</SemanticEnd>
+      <Alias>gt.sh.cli.scada.response.110</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recjhHMNWpqOA9zhW</SchemaId>
@@ -3789,8 +4278,8 @@
       <SchemaAttributes>reckbdPijd806F8LT</SchemaAttributes>
       <SchemaAttributes>recazWVfmVGIXktTn</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.dispatch.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recjwzTYeT77Cq7NZ</SchemaId>
@@ -3807,8 +4296,14 @@
       <MakeDataClass>true</MakeDataClass>
       <DataClass>ElectricHeaterCac</DataClass>
       <IsCac>true</IsCac>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.electric.heater.cac.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
+    </Schema>
+    <Schema>
+      <SchemaId>reckY63so20WXNDXO</SchemaId>
+      <createdTime>2022-07-05T11:32:39Z</createdTime>
+      <Alias>.</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recnOen6KenxkwQtB</SchemaId>
@@ -3821,21 +4316,35 @@
       <UsedAsSubMessagein>rechikfSomM4gopMG</UsedAsSubMessagein>
       <SemanticEnd>100</SemanticEnd>
       <DataClass>ThermalEdge</DataClass>
-      <ConsistencyCheck>0</ConsistencyCheck>
       <Alias>gt.thermal.edge.100</Alias>
+      <ConsistencyCheck>0</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recnUzSx1WgKUdTZO</SchemaId>
       <createdTime>2022-07-03T17:26:39Z</createdTime>
       <AliasRoot>gt.dispatch</AliasRoot>
-      <Status>Active</Status>
+      <Status>Deprecated</Status>
       <ProtocolType>Json</ProtocolType>
       <SchemaAttributes>recP1RBCr64M0yHV5</SchemaAttributes>
       <SchemaAttributes>reciVyeMslNHUJKN8</SchemaAttributes>
       <SchemaAttributes>rec96i0QHA47Ra3SD</SchemaAttributes>
       <SemanticEnd>110</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.dispatch.110</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
+    </Schema>
+    <Schema>
+      <SchemaId>recoAsAg06Qp7jYp3</SchemaId>
+      <createdTime>2022-07-05T11:32:40Z</createdTime>
+      <AliasRoot>gt.dispatch.boolean.local</AliasRoot>
+      <Status>Active</Status>
+      <ProtocolType>Json</ProtocolType>
+      <SchemaAttributes>recnqelpRWYmV8MJR</SchemaAttributes>
+      <SchemaAttributes>recWSgdPQdB9dVyux</SchemaAttributes>
+      <SchemaAttributes>recDMDjJ0WR1xxx1F</SchemaAttributes>
+      <SchemaAttributes>recNpHoc7bhC32M0w</SchemaAttributes>
+      <SemanticEnd>100</SemanticEnd>
+      <Alias>gt.dispatch.boolean.local.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recpr0byizj3PmqXi</SchemaId>
@@ -3853,8 +4362,8 @@
       <SemanticEnd>120</SemanticEnd>
       <MakeDataClass>true</MakeDataClass>
       <DataClass>ShNode</DataClass>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.node.120</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recqVHqZ5DQVdVgby</SchemaId>
@@ -3864,8 +4373,8 @@
       <ProtocolType>Json</ProtocolType>
       <Enums>rec2HyLffy6QK9QId</Enums>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.telemetry.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recrNYtQoRa7YhqI4</SchemaId>
@@ -3887,8 +4396,8 @@
       <MakeDataClass>true</MakeDataClass>
       <DataClass>TempSensorCac</DataClass>
       <IsCac>true</IsCac>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.temp.sensor.cac.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recsMoh2JkG2YPR8u</SchemaId>
@@ -3905,8 +4414,8 @@
       <MakeDataClass>true</MakeDataClass>
       <DataClass>ElectricMeterComponent</DataClass>
       <IsComponent>true</IsComponent>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.electric.meter.component.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recvoY8JOncNeQjYF</SchemaId>
@@ -3929,8 +4438,8 @@
       <SchemaAttributes>rec6F0YzYq2cynuBc</SchemaAttributes>
       <SchemaAttributes>recyiS4OAWw4Xe5dF</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.spaceheat.house.config.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recwcEF6jm0pivW8K</SchemaId>
@@ -3943,9 +4452,10 @@
       <SchemaAttributes>rec0SCL5wm4k2QtCO</SchemaAttributes>
       <SchemaAttributes>recgVLpaOczJX5BCi</SchemaAttributes>
       <UsedAsSubMessagein>recOWeL6PoLldCrop</UsedAsSubMessagein>
+      <UsedAsSubMessagein>recBtrSRyxjOXp8aA</UsedAsSubMessagein>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.simple.telemetry.status.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recx3kwLemvtMaT0t</SchemaId>
@@ -3958,8 +4468,8 @@
       <SchemaAttributes>recGRNEh1iK0tu10N</SchemaAttributes>
       <SchemaAttributes>recP42BiKvu4xhepH</SchemaAttributes>
       <SemanticEnd>100</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.telemetry.from.multipurpose.sensor.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recx4EL5mDebUhtzp</SchemaId>
@@ -3972,8 +4482,8 @@
       <SchemaAttributes>recKwPBxJr8R55KlB</SchemaAttributes>
       <SchemaAttributes>recfMyBibCC1lqTy1</SchemaAttributes>
       <SemanticEnd>110</SemanticEnd>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.telemetry.110</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recy2lAURQitTqKTR</SchemaId>
@@ -3991,8 +4501,8 @@
       <MakeDataClass>true</MakeDataClass>
       <DataClass>BooleanActuatorCac</DataClass>
       <IsCac>true</IsCac>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.boolean.actuator.cac.100</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
     <Schema>
       <SchemaId>recyuopIDguUgR1mI</SchemaId>
@@ -4005,10 +4515,11 @@
       <SchemaAttributes>rec367deUgDqEaq89</SchemaAttributes>
       <SchemaAttributes>recysUCe9haFiLkWl</SchemaAttributes>
       <UsedAsSubMessagein>recbRDhEoGNs9jYEB</UsedAsSubMessagein>
+      <UsedAsSubMessagein>recjXMbjBpdJFTXBi</UsedAsSubMessagein>
       <SemanticEnd>110</SemanticEnd>
       <SchemaAxioms>recsymqeqSBbr9R9o</SchemaAxioms>
-      <ConsistencyCheck>1</ConsistencyCheck>
       <Alias>gt.sh.status.snapshot.110</Alias>
+      <ConsistencyCheck>1</ConsistencyCheck>
     </Schema>
   </Schemas>
   <ShNodes>

--- a/gw_spaceheat/actors/actor_base.py
+++ b/gw_spaceheat/actors/actor_base.py
@@ -1,21 +1,72 @@
 import csv
+import json
+import os
 import threading
 import uuid
 from abc import ABC, abstractmethod
+from functools import cached_property
 from typing import List
 
-import helpers
 import paho.mqtt.client as mqtt
+
+import helpers
 import settings
+from actors.utils import QOS, Subscription
 from data_classes.sh_node import ShNode
 from schema.gs.gs_dispatch import GsDispatch
 from schema.gs.gs_pwr import GsPwr
 from schema.schema_switcher import TypeMakerByAliasDict
 
-from actors.utils import QOS, Subscription
-
 
 class ActorBase(ABC):
+    @cached_property
+    def atn_g_node_alias(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_atn_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyAtomicTNodeGNode"]
+        return my_atn_as_dict["Alias"]
+
+    @cached_property
+    def atn_g_node_id(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_atn_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyAtomicTNodeGNode"]
+        return my_atn_as_dict["GNodeId"]
+
+    @cached_property
+    def terminal_asset_g_node_alias(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_atn_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyTerminalAssetGNode"]
+        return my_atn_as_dict["Alias"]
+
+    @cached_property
+    def terminal_asset_g_node_id(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_atn_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyTerminalAssetGNode"]
+        return my_atn_as_dict["GNodeId"]
+
+    @cached_property
+    def scada_g_node_alias(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_scada_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyScadaGNode"]
+        return my_scada_as_dict["Alias"]
+
+    @cached_property
+    def scada_g_node_id(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_scada_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyScadaGNode"]
+        return my_scada_as_dict["GNodeId"]
+
     def __init__(self, node: ShNode, logging_on=False):
         self._main_loop_running = False
         self.main_thread = None

--- a/gw_spaceheat/actors/atn.py
+++ b/gw_spaceheat/actors/atn.py
@@ -2,7 +2,6 @@ import time
 import uuid
 from typing import Dict, List, Optional
 
-import helpers
 import load_house
 from actors.cloud_base import CloudBase
 from actors.utils import QOS, Subscription, responsive_sleep
@@ -10,7 +9,7 @@ from data_classes.components.boolean_actuator_component import BooleanActuatorCo
 from data_classes.sh_node import ShNode
 from schema.enums.role.role_map import Role
 from schema.gs.gs_pwr_maker import GsPwr, GsPwr_Maker
-from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch_Maker
+from schema.gt.gt_dispatch_boolean.gt_dispatch_boolean_maker import GtDispatchBoolean_Maker
 from schema.gt.gt_sh_cli_atn_cmd.gt_sh_cli_atn_cmd_maker import GtShCliAtnCmd_Maker
 from schema.gt.gt_sh_cli_scada_response.gt_sh_cli_scada_response_maker import (
     GtShCliScadaResponse,
@@ -106,22 +105,36 @@ class Atn(CloudBase):
     ################################################
 
     def status(self):
-        payload = GtShCliAtnCmd_Maker(send_snapshot=True).tuple
+        payload = GtShCliAtnCmd_Maker(
+            from_g_node_alias=self.atn_g_node_alias,
+            from_g_node_id=self.atn_g_node_id,
+            send_snapshot=True,
+        ).tuple
         self.gw_publish(payload)
 
     def turn_on(self, ba: ShNode):
         if not isinstance(ba.component, BooleanActuatorComponent):
             raise Exception(f"{ba} must be a BooleanActuator!")
-        payload = GtDispatch_Maker(
-            relay_state=1, sh_node_alias=ba.alias, send_time_unix_ms=int(time.time() * 1000)
+        payload = GtDispatchBoolean_Maker(
+            to_g_node_alias=self.scada_g_node_alias,
+            from_g_node_alias=self.atn_g_node_alias,
+            from_g_node_id=self.atn_g_node_id,
+            about_node_alias=ba.alias,
+            relay_state=1,
+            send_time_unix_ms=int(time.time() * 1000),
         ).tuple
         self.gw_publish(payload)
 
     def turn_off(self, ba: ShNode):
         if not isinstance(ba.component, BooleanActuatorComponent):
             raise Exception(f"{ba} must be a BooleanActuator!")
-        payload = GtDispatch_Maker(
-            relay_state=0, sh_node_alias=ba.alias, send_time_unix_ms=int(time.time() * 1000)
+        payload = GtDispatchBoolean_Maker(
+            to_g_node_alias=self.scada_g_node_alias,
+            from_g_node_alias=self.atn_g_node_alias,
+            from_g_node_id=self.atn_g_node_id,
+            about_node_alias=ba.alias,
+            relay_state=0,
+            send_time_unix_ms=int(time.time() * 1000),
         ).tuple
         self.gw_publish(payload)
 

--- a/gw_spaceheat/actors/atn.py
+++ b/gw_spaceheat/actors/atn.py
@@ -1,8 +1,11 @@
+import time
 import uuid
 from typing import Dict, List, Optional
-import time
+
 import helpers
 import load_house
+from actors.cloud_base import CloudBase
+from actors.utils import QOS, Subscription, responsive_sleep
 from data_classes.components.boolean_actuator_component import BooleanActuatorComponent
 from data_classes.sh_node import ShNode
 from schema.enums.role.role_map import Role
@@ -13,14 +16,7 @@ from schema.gt.gt_sh_cli_scada_response.gt_sh_cli_scada_response_maker import (
     GtShCliScadaResponse,
     GtShCliScadaResponse_Maker,
 )
-
-from schema.gt.gt_sh_status.gt_sh_status_maker import (
-    GtShStatus,
-    GtShStatus_Maker,
-)
-
-from actors.cloud_base import CloudBase
-from actors.utils import QOS, Subscription, responsive_sleep
+from schema.gt.gt_sh_status.gt_sh_status_maker import GtShStatus, GtShStatus_Maker
 
 
 class Atn(CloudBase):
@@ -61,15 +57,15 @@ class Atn(CloudBase):
     def gw_subscriptions(self) -> List[Subscription]:
         return [
             Subscription(
-                Topic=f"{helpers.scada_g_node_alias()}/{GsPwr_Maker.type_alias}",
+                Topic=f"{self.scada_g_node_alias}/{GsPwr_Maker.type_alias}",
                 Qos=QOS.AtMostOnce,
             ),
             Subscription(
-                Topic=f"{helpers.scada_g_node_alias()}/{GtShStatus_Maker.type_alias}",
+                Topic=f"{self.scada_g_node_alias}/{GtShStatus_Maker.type_alias}",
                 Qos=QOS.AtLeastOnce,
             ),
             Subscription(
-                Topic=f"{helpers.scada_g_node_alias()}/{GtShCliScadaResponse_Maker.type_alias}",
+                Topic=f"{self.scada_g_node_alias}/{GtShCliScadaResponse_Maker.type_alias}",
                 Qos=QOS.AtLeastOnce,
             ),
         ]

--- a/gw_spaceheat/actors/boolean_actuator.py
+++ b/gw_spaceheat/actors/boolean_actuator.py
@@ -1,18 +1,15 @@
 import time
 from typing import List, Optional
 
+from actors.actor_base import ActorBase
+from actors.utils import QOS, Subscription, responsive_sleep
 from data_classes.node_config import NodeConfig
 from data_classes.sh_node import ShNode
-
+from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch, GtDispatch_Maker
 from schema.gt.gt_driver_booleanactuator_cmd.gt_driver_booleanactuator_cmd_maker import (
     GtDriverBooleanactuatorCmd_Maker,
 )
-
-from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch, GtDispatch_Maker
 from schema.gt.gt_telemetry.gt_telemetry_maker import GtTelemetry_Maker
-
-from actors.actor_base import ActorBase
-from actors.utils import QOS, Subscription, responsive_sleep
 
 
 class BooleanActuator(ActorBase):

--- a/gw_spaceheat/actors/boolean_actuator.py
+++ b/gw_spaceheat/actors/boolean_actuator.py
@@ -5,7 +5,11 @@ from actors.actor_base import ActorBase
 from actors.utils import QOS, Subscription, responsive_sleep
 from data_classes.node_config import NodeConfig
 from data_classes.sh_node import ShNode
-from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch, GtDispatch_Maker
+from schema.gt.gt_dispatch_boolean_local.gt_dispatch_boolean_local_maker import (
+    GtDispatchBooleanLocal,
+    GtDispatchBooleanLocal_Maker,
+)
+
 from schema.gt.gt_driver_booleanactuator_cmd.gt_driver_booleanactuator_cmd_maker import (
     GtDriverBooleanactuatorCmd_Maker,
 )
@@ -29,13 +33,13 @@ class BooleanActuator(ActorBase):
 
     def subscriptions(self) -> List[Subscription]:
         my_subscriptions = [
-            Subscription(Topic=f"a.s/{GtDispatch_Maker.type_alias}", Qos=QOS.AtMostOnce)
+            Subscription(Topic=f"a.s/{GtDispatchBooleanLocal_Maker.type_alias}", Qos=QOS.AtMostOnce)
         ]
         return my_subscriptions
 
     def on_message(self, from_node: ShNode, payload):
-        if isinstance(payload, GtDispatch):
-            self.gt_dispatch_received(from_node, payload)
+        if isinstance(payload, GtDispatchBooleanLocal):
+            self.gt_dispatch_boolean_local_received(from_node, payload)
         else:
             self.screen_print(f"{payload} subscription not implemented!")
 
@@ -53,10 +57,12 @@ class BooleanActuator(ActorBase):
         if relay_state == 1:
             self.config.driver.turn_on()
 
-    def gt_dispatch_received(self, from_node: ShNode, payload: GtDispatch):
+    def gt_dispatch_boolean_local_received(
+        self, from_node: ShNode, payload: GtDispatchBooleanLocal
+    ):
         if from_node != ShNode.by_alias["a.s"]:
             raise Exception(f"Only responds to dispatch from Scada. Got dispatch from {from_node}")
-        if payload.ShNodeAlias == self.node.alias:
+        if payload.AboutNodeAlias == self.node.alias:
             self.dispatch_relay(payload.RelayState)
             if self.relay_state != payload.RelayState:
                 self.update_and_report_state_change()

--- a/gw_spaceheat/actors/cloud_base.py
+++ b/gw_spaceheat/actors/cloud_base.py
@@ -1,21 +1,73 @@
 import csv
+import json
+import os
 import threading
 import uuid
 from abc import ABC, abstractmethod
+from functools import cached_property
 from typing import List
+
+import paho.mqtt.client as mqtt
 
 import helpers
 import load_house
-import paho.mqtt.client as mqtt
 import settings
+from actors.utils import QOS, Subscription
 from data_classes.sh_node import ShNode
 from schema.gs.gs_dispatch_maker import GsDispatch
 from schema.gs.gs_pwr_maker import GsPwr
 from schema.schema_switcher import TypeMakerByAliasDict
-from actors.utils import QOS, Subscription
 
 
 class CloudBase(ABC):
+    @cached_property
+    def atn_g_node_alias(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_atn_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyAtomicTNodeGNode"]
+        return my_atn_as_dict["Alias"]
+
+    @cached_property
+    def atn_g_node_id(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_atn_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyAtomicTNodeGNode"]
+        return my_atn_as_dict["GNodeId"]
+
+    @cached_property
+    def terminal_asset_g_node_alias(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_atn_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyTerminalAssetGNode"]
+        return my_atn_as_dict["Alias"]
+
+    @cached_property
+    def terminal_asset_g_node_id(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_atn_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyTerminalAssetGNode"]
+        return my_atn_as_dict["GNodeId"]
+
+    @cached_property
+    def scada_g_node_alias(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_scada_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyScadaGNode"]
+        return my_scada_as_dict["Alias"]
+
+    @cached_property
+    def scada_g_node_id(cls):
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, "../input_data/houses.json"), "r") as read_file:
+            input_data = json.load(read_file)
+        my_scada_as_dict = input_data[settings.WORLD_ROOT_ALIAS]["MyScadaGNode"]
+        return my_scada_as_dict["GNodeId"]
+
     def __init__(self, logging_on=False):
         self._main_loop_running = False
         self.main_thread = None
@@ -83,9 +135,9 @@ class CloudBase(ABC):
             (from_alias, type_alias) = message.topic.split("/")
         except IndexError:
             raise Exception("topic must be of format A/B")
-        if from_alias != helpers.scada_g_node_alias() and from_alias != helpers.atn_g_node_alias():
+        if from_alias != self.scada_g_node_alias and from_alias != self.atn_g_node_alias:
             raise Exception(f"alias {from_alias} not my Scada or Atn!")
-        if from_alias == helpers.scada_g_node_alias():
+        if from_alias == self.scada_g_node_alias:
             from_node = ShNode.by_alias["a.s"]
         else:
             from_node = ShNode.by_alias["a"]
@@ -106,7 +158,7 @@ class CloudBase(ABC):
         else:
             qos = QOS.AtLeastOnce
         self.gw_client.publish(
-            topic=f"{settings.ATN_G_NODE_ALIAS}/{payload.TypeAlias}",
+            topic=f"{self.atn_g_node_alias}/{payload.TypeAlias}",
             payload=payload.as_type(),
             qos=qos.value,
             retain=False,

--- a/gw_spaceheat/actors/cloud_ear.py
+++ b/gw_spaceheat/actors/cloud_ear.py
@@ -10,7 +10,11 @@ from actors.cloud_base import CloudBase
 from actors.utils import QOS, Subscription, responsive_sleep
 from data_classes.sh_node import ShNode
 from schema.gs.gs_pwr_maker import GsPwr, GsPwr_Maker
-from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch, GtDispatch_Maker
+
+from schema.gt.gt_dispatch_boolean.gt_dispatch_boolean_maker import (
+    GtDispatchBoolean,
+    GtDispatchBoolean_Maker,
+)
 from schema.gt.gt_sh_cli_scada_response.gt_sh_cli_scada_response_maker import (
     GtShCliScadaResponse_Maker,
 )
@@ -65,11 +69,7 @@ class CloudEar(CloudBase):
                 Qos=QOS.AtLeastOnce,
             ),
             Subscription(
-                Topic=f"{self.scada_g_node_alias}/{GtDispatch_Maker.type_alias}",
-                Qos=QOS.AtLeastOnce,
-            ),
-            Subscription(
-                Topic=f"{self.atn_g_node_alias}/{GtDispatch_Maker.type_alias}",
+                Topic=f"{self.atn_g_node_alias}/{GtDispatchBoolean_Maker.type_alias}",
                 Qos=QOS.AtLeastOnce,
             ),
         ]
@@ -80,7 +80,7 @@ class CloudEar(CloudBase):
             self.gs_pwr_received(from_node, payload)
         elif isinstance(payload, GtShStatus):
             self.gt_sh_status_received(from_node, payload)
-        elif isinstance(payload, GtDispatch):
+        elif isinstance(payload, GtDispatchBoolean):
             self.gt_dispatch_received(from_node, payload)
 
     def send_to_kafka(self, payload):
@@ -88,11 +88,11 @@ class CloudEar(CloudBase):
         # publish payload.as_type() to topic in Kafka
         pass
 
-    def gt_dispatch_received(self, from_node: ShNode, payload: GtDispatch):
+    def gt_dispatch_received(self, from_node: ShNode, payload: GtDispatchBoolean):
         if self.write_to_csv:
             self.log_dispatch_cmds_to_csv(from_node, payload)
 
-    def log_dispatch_cmds_to_csv(self, from_node: ShNode, payload: GtDispatch):
+    def log_dispatch_cmds_to_csv(self, from_node: ShNode, payload: GtDispatchBoolean):
         time_unix_ms = payload.SendTimeUnixMs
         int_time_unix_s = int(time_unix_ms / 1000)
         ms = int(time_unix_ms) % 1000

--- a/gw_spaceheat/actors/cloud_ear.py
+++ b/gw_spaceheat/actors/cloud_ear.py
@@ -1,58 +1,21 @@
-import csv
-import time
-import uuid
 from typing import List
 
-import pendulum
-
-import settings
-from actors.cloud_base import CloudBase
-from actors.utils import QOS, Subscription, responsive_sleep
 from data_classes.sh_node import ShNode
-from schema.gs.gs_pwr_maker import GsPwr, GsPwr_Maker
-
-from schema.gt.gt_dispatch_boolean.gt_dispatch_boolean_maker import (
-    GtDispatchBoolean,
-    GtDispatchBoolean_Maker,
-)
+from schema.gs.gs_pwr_maker import GsPwr_Maker
+from schema.gt.gt_dispatch_boolean.gt_dispatch_boolean_maker import GtDispatchBoolean_Maker
 from schema.gt.gt_sh_cli_scada_response.gt_sh_cli_scada_response_maker import (
     GtShCliScadaResponse_Maker,
 )
-from schema.gt.gt_sh_status.gt_sh_status_maker import GtShStatus, GtShStatus_Maker
+from schema.gt.gt_sh_status.gt_sh_status_maker import GtShStatus_Maker
 
-OUT_STUB = "output/status"
+from actors.cloud_base import CloudBase
+from actors.utils import QOS, Subscription, responsive_sleep
 
 
 class CloudEar(CloudBase):
-    def __init__(self, out_stub=OUT_STUB, logging_on=False):
-        if out_stub is None:
-            self.write_to_csv = False
-        else:
-            self.write_to_csv = True
+    def __init__(self, logging_on=False):
         super(CloudEar, self).__init__(logging_on=logging_on)
-        self.log_csv = f"output/debug_logs/ear_{str(uuid.uuid4()).split('-')[1]}.csv"
-        self.load_sh_nodes()
-        self.csv_rows = []
-        if self.write_to_csv:
-            adder = str(uuid.uuid4()).split("-")[1]
-            atn_ender = settings.ATN_G_NODE_ALIAS.replace(".", "_")
-            self.out_telemetry = f"{out_stub}/{atn_ender}_{adder}.csv"
-            self.screen_print(f"writing output headers ending in {adder}")
-            with open(self.out_telemetry, "w") as outfile:
-                write = csv.writer(outfile, delimiter=",")
-                write.writerow(
-                    [
-                        "TimeUtc",
-                        "TimeUnixS",
-                        "Ms",
-                        "About",
-                        "Value",
-                        "TelemetryName",
-                        "Sensor",
-                        "RelayCmd",
-                        "CmdFrom",
-                    ]
-                )
+
         self.screen_print(f"Initialized {self.__class__}")
 
     def gw_subscriptions(self) -> List[Subscription]:
@@ -75,114 +38,7 @@ class CloudEar(CloudBase):
         ]
 
     def on_gw_message(self, from_node: ShNode, payload):
-        self.send_to_kafka(payload=payload)
-        if isinstance(payload, GsPwr):
-            self.gs_pwr_received(from_node, payload)
-        elif isinstance(payload, GtShStatus):
-            self.gt_sh_status_received(from_node, payload)
-        elif isinstance(payload, GtDispatchBoolean):
-            self.gt_dispatch_received(from_node, payload)
-
-    def send_to_kafka(self, payload):
-        # topic = f"{self.scada_g_node_alias}/{payload.TypeAlias}"
-        # publish payload.as_type() to topic in Kafka
         pass
-
-    def gt_dispatch_received(self, from_node: ShNode, payload: GtDispatchBoolean):
-        if self.write_to_csv:
-            self.log_dispatch_cmds_to_csv(from_node, payload)
-
-    def log_dispatch_cmds_to_csv(self, from_node: ShNode, payload: GtDispatchBoolean):
-        time_unix_ms = payload.SendTimeUnixMs
-        int_time_unix_s = int(time_unix_ms / 1000)
-        ms = int(time_unix_ms) % 1000
-        time_utc = pendulum.from_timestamp(int_time_unix_s)
-        row = [
-            time_utc.strftime("%Y-%m-%d %H:%M:%S"),
-            int_time_unix_s,
-            ms,
-            payload.ShNodeAlias,
-            "",
-            "",
-            "",
-            payload.RelayState,
-            from_node.alias,
-        ]
-        self.csv_rows.append(row)
-
-    def gt_sh_status_received(self, from_node: ShNode, payload: GtShStatus):
-        self.screen_print(f"Consider adding from_node {from_node} or its g node alias to log?")
-        if self.write_to_csv:
-            self.log_status_csv(payload=payload)
-
-    def gs_pwr_received(self, from_node: ShNode, payload: GsPwr):
-        pass
-
-    def log_status_csv(self, payload: GtShStatus):
-        for status in payload.SimpleTelemetryList:
-            for i in range(len(status.ValueList)):
-                time_unix_ms = status.ReadTimeUnixMsList[i]
-                int_time_unix_s = int(time_unix_ms / 1000)
-                ms = int(time_unix_ms) % 1000
-                time_utc = pendulum.from_timestamp(int_time_unix_s)
-                self.csv_rows.append(
-                    [
-                        time_utc.strftime("%Y-%m-%d %H:%M:%S"),
-                        int_time_unix_s,
-                        ms,
-                        status.ShNodeAlias,
-                        status.ValueList[i],
-                        status.TelemetryName.value,
-                    ]
-                )
-
-        for status in payload.MultipurposeTelemetryList:
-            for i in range(len(status.ValueList)):
-                time_unix_ms = status.ReadTimeUnixMsList[i]
-                int_time_unix_s = int(time_unix_ms / 1000)
-                ms = int(time_unix_ms) % 1000
-                time_utc = pendulum.from_timestamp(int_time_unix_s)
-                self.csv_rows.append(
-                    [
-                        time_utc.strftime("%Y-%m-%d %H:%M:%S"),
-                        int_time_unix_s,
-                        ms,
-                        status.AboutNodeAlias,
-                        status.ValueList[i],
-                        status.TelemetryName.value,
-                        status.SensorNodeAlias,
-                    ]
-                )
-
-        for status in payload.BooleanactuatorCmdList:
-            for i in range(len(status.RelayStateCommandList)):
-                time_unix_ms = status.CommandTimeUnixMsList[i]
-                int_time_unix_s = int(time_unix_ms / 1000)
-                ms = int(time_unix_ms) % 1000
-                time_utc = pendulum.from_timestamp(int_time_unix_s)
-                self.csv_rows.append(
-                    [
-                        time_utc.strftime("%Y-%m-%d %H:%M:%S"),
-                        int_time_unix_s,
-                        ms,
-                        status.ShNodeAlias,
-                        "",
-                        "",
-                        "",
-                        status.RelayStateCommandList[i],
-                        status.ShNodeAlias,
-                    ]
-                )
-
-        self.screen_print(f"appending output to {self.out_telemetry.split('_')[-1]}")
-        now_utc = pendulum.from_timestamp(int(time.time()))
-        self.screen_print(f'{now_utc.strftime("%Y-%m-%d %H:%M:%S")}')
-        rows = sorted(self.csv_rows, key=lambda x: x[1] * 1000 + x[2])
-        with open(self.out_telemetry, "a") as outfile:
-            write = csv.writer(outfile, delimiter=",")
-            for row in rows:
-                write.writerow(row)
-        self.csv_rows = []
 
     def main(self):
         self._main_loop_running = True

--- a/gw_spaceheat/actors/cloud_ear.py
+++ b/gw_spaceheat/actors/cloud_ear.py
@@ -3,24 +3,18 @@ import time
 import uuid
 from typing import List
 
-import helpers
 import pendulum
+
 import settings
+from actors.cloud_base import CloudBase
+from actors.utils import QOS, Subscription, responsive_sleep
 from data_classes.sh_node import ShNode
 from schema.gs.gs_pwr_maker import GsPwr, GsPwr_Maker
-
-from schema.gt.gt_sh_status.gt_sh_status_maker import (
-    GtShStatus,
-    GtShStatus_Maker,
-)
+from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch, GtDispatch_Maker
 from schema.gt.gt_sh_cli_scada_response.gt_sh_cli_scada_response_maker import (
     GtShCliScadaResponse_Maker,
 )
-
-from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch, GtDispatch_Maker
-
-from actors.cloud_base import CloudBase
-from actors.utils import QOS, Subscription, responsive_sleep
+from schema.gt.gt_sh_status.gt_sh_status_maker import GtShStatus, GtShStatus_Maker
 
 OUT_STUB = "output/status"
 
@@ -60,22 +54,22 @@ class CloudEar(CloudBase):
     def gw_subscriptions(self) -> List[Subscription]:
         return [
             Subscription(
-                Topic=f"{helpers.scada_g_node_alias()}/{GsPwr_Maker.type_alias}", Qos=QOS.AtMostOnce
+                Topic=f"{self.scada_g_node_alias}/{GsPwr_Maker.type_alias}", Qos=QOS.AtMostOnce
             ),
             Subscription(
-                Topic=f"{helpers.scada_g_node_alias()}/{GtShStatus_Maker.type_alias}",
+                Topic=f"{self.scada_g_node_alias}/{GtShStatus_Maker.type_alias}",
                 Qos=QOS.AtLeastOnce,
             ),
             Subscription(
-                Topic=f"{helpers.scada_g_node_alias()}/{GtShCliScadaResponse_Maker.type_alias}",
+                Topic=f"{self.scada_g_node_alias}/{GtShCliScadaResponse_Maker.type_alias}",
                 Qos=QOS.AtLeastOnce,
             ),
             Subscription(
-                Topic=f"{helpers.scada_g_node_alias()}/{GtDispatch_Maker.type_alias}",
+                Topic=f"{self.scada_g_node_alias}/{GtDispatch_Maker.type_alias}",
                 Qos=QOS.AtLeastOnce,
             ),
             Subscription(
-                Topic=f"{helpers.atn_g_node_alias()}/{GtDispatch_Maker.type_alias}",
+                Topic=f"{self.atn_g_node_alias}/{GtDispatch_Maker.type_alias}",
                 Qos=QOS.AtLeastOnce,
             ),
         ]
@@ -90,7 +84,7 @@ class CloudEar(CloudBase):
             self.gt_dispatch_received(from_node, payload)
 
     def send_to_kafka(self, payload):
-        # topic = f"{helpers.scada_g_node_alias()}/{payload.TypeAlias}"
+        # topic = f"{self.scada_g_node_alias}/{payload.TypeAlias}"
         # publish payload.as_type() to topic in Kafka
         pass
 

--- a/gw_spaceheat/actors/home_alone.py
+++ b/gw_spaceheat/actors/home_alone.py
@@ -1,14 +1,9 @@
 from typing import List, Optional
 
-import helpers
-from data_classes.sh_node import ShNode
-from schema.gt.gt_sh_status.gt_sh_status_maker import (
-    GtShStatus,
-    GtShStatus_Maker,
-)
-
 from actors.actor_base import ActorBase
 from actors.utils import QOS, Subscription, responsive_sleep
+from data_classes.sh_node import ShNode
+from schema.gt.gt_sh_status.gt_sh_status_maker import GtShStatus, GtShStatus_Maker
 
 
 class HomeAlone(ActorBase):
@@ -22,7 +17,7 @@ class HomeAlone(ActorBase):
     def subscriptions(self) -> List[Subscription]:
         my_subscriptions = [
             Subscription(
-                Topic=f"{helpers.scada_g_node_alias()}/{GtShStatus_Maker.type_alias}",
+                Topic=f"{self.scada_g_node_alias}/{GtShStatus_Maker.type_alias}",
                 Qos=QOS.AtLeastOnce,
             )
         ]

--- a/gw_spaceheat/actors/power_meter.py
+++ b/gw_spaceheat/actors/power_meter.py
@@ -1,17 +1,16 @@
 import time
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
+from actors.actor_base import ActorBase
+from actors.utils import Subscription, responsive_sleep
 from data_classes.node_config import NodeConfig
 from data_classes.sh_node import ShNode
 from named_tuples.telemetry_tuple import TelemetryTuple
 from schema.enums.telemetry_name.telemetry_name_map import TelemetryName
+from schema.gt.gt_eq_reporting_config.gt_eq_reporting_config import GtEqReportingConfig
 from schema.gt.gt_sh_telemetry_from_multipurpose_sensor.gt_sh_telemetry_from_multipurpose_sensor_maker import (
     GtShTelemetryFromMultipurposeSensor_Maker,
 )
-
-from schema.gt.gt_eq_reporting_config.gt_eq_reporting_config import GtEqReportingConfig
-from actors.actor_base import ActorBase
-from actors.utils import Subscription, responsive_sleep
 
 
 class PowerMeter(ActorBase):

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -2,8 +2,8 @@ import enum
 import time
 from typing import Dict, List, Optional
 
+import uuid
 import pendulum
-
 import settings
 from actors.scada_base import ScadaBase
 from actors.utils import QOS, Subscription, responsive_sleep
@@ -15,7 +15,16 @@ from schema.enums.role.role_map import Role
 from schema.enums.telemetry_name.telemetry_name_map import TelemetryName
 from schema.gs.gs_dispatch_maker import GsDispatch
 from schema.gs.gs_pwr_maker import GsPwr, GsPwr_Maker
-from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch, GtDispatch_Maker
+from schema.gt.gt_dispatch_boolean.gt_dispatch_boolean_maker import (
+    GtDispatchBoolean,
+    GtDispatchBoolean_Maker,
+)
+
+from schema.gt.gt_dispatch_boolean_local.gt_dispatch_boolean_local_maker import (
+    GtDispatchBooleanLocal_Maker,
+    GtDispatchBooleanLocal,
+)
+
 from schema.gt.gt_driver_booleanactuator_cmd.gt_driver_booleanactuator_cmd_maker import (
     GtDriverBooleanactuatorCmd,
     GtDriverBooleanactuatorCmd_Maker,
@@ -36,7 +45,7 @@ from schema.gt.gt_sh_simple_telemetry_status.gt_sh_simple_telemetry_status_maker
     GtShSimpleTelemetryStatus,
     GtShSimpleTelemetryStatus_Maker,
 )
-from schema.gt.gt_sh_status.gt_sh_status_maker import GtShStatus_Maker
+from schema.gt.gt_sh_status.gt_sh_status_maker import GtShStatus_Maker, GtShStatus
 from schema.gt.gt_sh_status_snapshot.gt_sh_status_snapshot_maker import (
     GtShStatusSnapshot,
     GtShStatusSnapshot_Maker,
@@ -84,6 +93,12 @@ class Scada(ScadaBase):
         super(Scada, self).__init__(node=node, logging_on=logging_on)
         now = int(time.time())
         self._last_5_cron_s = now - (now % 300)
+
+        # status_to_store is a placeholder Dict of GtShStatus
+        # objects by StatusUid key that we want to store
+        # (probably about 3 weeks worth) and access on restart
+
+        self.status_to_store: Dict[str:GtShStatus] = {}
         self.power = 0
         self.total_power_w = 0
         self.config: Dict[ShNode, NodeConfig] = {}
@@ -179,8 +194,8 @@ class Scada(ScadaBase):
             self.gs_pwr_received(from_node, payload)
         elif isinstance(payload, GsDispatch):
             self.gs_dispatch_received(from_node, payload)
-        elif isinstance(payload, GtDispatch):
-            self.gt_dispatch_received(from_node, payload)
+        elif isinstance(payload, GtDispatchBooleanLocal):
+            self.gt_dispatch_boolean_local_received(from_node, payload)
         elif isinstance(payload, GtTelemetry):
             self.gt_telemetry_received(from_node, payload),
         elif isinstance(payload, GtShTelemetryFromMultipurposeSensor):
@@ -195,6 +210,11 @@ class Scada(ScadaBase):
             raise Exception("Need to track all metering and make sure we have the sum")
         self.total_power_w = payload.Power
         self.gw_publish(payload=payload)
+
+    def gt_dispatch_boolean_local_received(self, payload: GtDispatchBooleanLocal):
+        """This will be a message from HomeAlone, honored when the DispatchContract
+        with the Atn is not live."""
+        raise NotImplementedError
 
     def gt_sh_telemetry_from_multipurpose_sensor_received(
         self, from_node: ShNode, payload: GtShTelemetryFromMultipurposeSensor
@@ -259,7 +279,7 @@ class Scada(ScadaBase):
     def gw_subscriptions(self) -> List[Subscription]:
         return [
             Subscription(
-                Topic=f"{self.atn_g_node_alias}/{GtDispatch_Maker.type_alias}",
+                Topic=f"{self.atn_g_node_alias}/{GtDispatchBoolean_Maker.type_alias}",
                 Qos=QOS.AtLeastOnce,
             ),
             Subscription(
@@ -274,8 +294,8 @@ class Scada(ScadaBase):
         if isinstance(payload, GsDispatch):
             self.gs_dispatch_received(from_node, payload)
             return ScadaCmdDiagnostic.SUCCESS
-        elif isinstance(payload, GtDispatch):
-            self.gt_dispatch_received(from_node, payload)
+        elif isinstance(payload, GtDispatchBoolean):
+            self.gt_dispatch_boolean_received(payload)
             return ScadaCmdDiagnostic.SUCCESS
         elif isinstance(payload, GtShCliAtnCmd):
             self.gt_sh_cli_atn_cmd_received(payload)
@@ -287,12 +307,14 @@ class Scada(ScadaBase):
     def gs_dispatch_received(self, from_node: ShNode, payload: GsDispatch):
         raise NotImplementedError
 
-    def gt_dispatch_received(self, from_node: ShNode, payload: GtDispatch):
-        self.screen_print(f"received {payload} from {from_node}")
-        if payload.ShNodeAlias not in ShNode.by_alias.keys():
-            self.screen_print(f"dispatch received for unknnown sh_node {payload.ShNodeAlias}")
+    def gt_dispatch_boolean_received(self, payload: GtDispatchBoolean):
+        """This is a dispatch message received from the atn. It is
+        honored whenever DispatchContract is live."""
+
+        if payload.AboutNodeAlias not in ShNode.by_alias.keys():
+            self.screen_print(f"dispatch received for unknnown sh_node {payload.AboutNodeAlias}")
             return
-        ba = ShNode.by_alias[payload.ShNodeAlias]
+        ba = ShNode.by_alias[payload.AboutNodeAlias]
         if not isinstance(ba.component, BooleanActuatorComponent):
             self.screen_print(f"{ba} must be a BooleanActuator!")
             return
@@ -327,7 +349,11 @@ class Scada(ScadaBase):
             return
 
         snapshot = self.make_status_snapshot()
-        payload = GtShCliScadaResponse_Maker(snapshot=snapshot).tuple
+        payload = GtShCliScadaResponse_Maker(
+            from_g_node_alias=self.scada_g_node_alias,
+            from_g_node_id=self.scada_g_node_id,
+            snapshot=snapshot,
+        ).tuple
         self.gw_publish(payload=payload)
 
     ################################################
@@ -337,8 +363,11 @@ class Scada(ScadaBase):
     def turn_on(self, ba: ShNode) -> ScadaCmdDiagnostic:
         if not isinstance(ba.component, BooleanActuatorComponent):
             return ScadaCmdDiagnostic.DISPATCH_NODE_NOT_BOOLEAN_ACTUATOR
-        dispatch_payload = GtDispatch_Maker(
-            relay_state=1, sh_node_alias=ba.alias, send_time_unix_ms=int(time.time() * 1000)
+        dispatch_payload = GtDispatchBooleanLocal_Maker(
+            from_node_alias=self.node.alias,
+            about_node_alias=ba.alias,
+            relay_state=1,
+            send_time_unix_ms=int(time.time() * 1000),
         ).tuple
         self.publish(payload=dispatch_payload)
         self.gw_publish(payload=dispatch_payload)
@@ -348,8 +377,11 @@ class Scada(ScadaBase):
     def turn_off(self, ba: ShNode):
         if not isinstance(ba.component, BooleanActuatorComponent):
             return ScadaCmdDiagnostic.DISPATCH_NODE_NOT_BOOLEAN_ACTUATOR
-        dispatch_payload = GtDispatch_Maker(
-            relay_state=0, sh_node_alias=ba.alias, send_time_unix_ms=int(time.time() * 1000)
+        dispatch_payload = GtDispatchBooleanLocal_Maker(
+            from_node_alias=self.node.alias,
+            about_node_alias=ba.alias,
+            relay_state=0,
+            send_time_unix_ms=int(time.time() * 1000),
         ).tuple
         self.publish(payload=dispatch_payload)
         self.gw_publish(payload=dispatch_payload)
@@ -422,7 +454,10 @@ class Scada(ScadaBase):
                 booleanactuator_cmd_list.append(status)
 
         slot_start_unix_s = self._last_5_cron_s
-        payload = GtShStatus_Maker(
+        status = GtShStatus_Maker(
+            from_g_node_alias=self.scada_g_node_alias,
+            from_g_node_id=self.scada_g_node_id,
+            status_uid=str(uuid.uuid4()),
             about_g_node_alias=self.terminal_asset_g_node_alias,
             slot_start_unix_s=slot_start_unix_s,
             reporting_period_s=settings.SCADA_REPORTING_PERIOD_S,
@@ -430,8 +465,8 @@ class Scada(ScadaBase):
             multipurpose_telemetry_list=multipurpose_telemetry_list,
             simple_telemetry_list=simple_telemetry_list,
         ).tuple
-        self.payload = payload
-        self.gw_publish(payload)
+        self.status_to_store[status.StatusUid] = status
+        self.gw_publish(status)
         self.flush_latest_readings()
 
     def cron_every_5(self):

--- a/gw_spaceheat/actors/scada_base.py
+++ b/gw_spaceheat/actors/scada_base.py
@@ -1,16 +1,16 @@
 import uuid
 from abc import abstractmethod
 
-import helpers
 import paho.mqtt.client as mqtt
+
+import helpers
 import settings
+from actors.actor_base import ActorBase
+from actors.utils import QOS
 from data_classes.sh_node import ShNode
 from schema.gs.gs_dispatch_maker import GsDispatch
 from schema.gs.gs_pwr import GsPwr
 from schema.schema_switcher import TypeMakerByAliasDict
-
-from actors.actor_base import ActorBase
-from actors.utils import QOS
 
 
 class ScadaBase(ActorBase):
@@ -65,7 +65,7 @@ class ScadaBase(ActorBase):
             (from_alias, type_alias) = message.topic.split("/")
         except IndexError:
             raise Exception("topic must be of format A/B")
-        if from_alias != settings.ATN_G_NODE_ALIAS:
+        if from_alias != self.atn_g_node_alias:
             raise Exception(f"alias {from_alias} not my AtomicTNode!")
         if type_alias not in TypeMakerByAliasDict.keys():
             raise Exception(f"Type {type_alias} not recognized. Should be in TypeByAliasDict keys!")
@@ -82,7 +82,7 @@ class ScadaBase(ActorBase):
         else:
             qos = QOS.AtLeastOnce
         self.gw_client.publish(
-            topic=f"{helpers.scada_g_node_alias()}/{payload.TypeAlias}",
+            topic=f"{self.scada_g_node_alias}/{payload.TypeAlias}",
             payload=payload.as_type(),
             qos=qos.value,
             retain=False,

--- a/gw_spaceheat/actors/simple_sensor.py
+++ b/gw_spaceheat/actors/simple_sensor.py
@@ -1,12 +1,11 @@
 import time
 from typing import List
 
+from actors.actor_base import ActorBase
+from actors.utils import Subscription, responsive_sleep
 from data_classes.node_config import NodeConfig
 from data_classes.sh_node import ShNode
 from schema.gt.gt_telemetry.gt_telemetry_maker import GtTelemetry_Maker
-
-from actors.actor_base import ActorBase
-from actors.utils import Subscription, responsive_sleep
 
 
 class SimpleSensor(ActorBase):

--- a/gw_spaceheat/actors/strategy_switcher.py
+++ b/gw_spaceheat/actors/strategy_switcher.py
@@ -1,12 +1,11 @@
-from data_classes.sh_node import ShNode
-from schema.enums.actor_class.actor_class_map import ActorClass
-
 from actors.atn import Atn
 from actors.boolean_actuator import BooleanActuator
 from actors.home_alone import HomeAlone
 from actors.power_meter import PowerMeter
 from actors.scada import Scada
 from actors.simple_sensor import SimpleSensor
+from data_classes.sh_node import ShNode
+from schema.enums.actor_class.actor_class_map import ActorClass
 
 switcher = {
     ActorClass.ATN: Atn,

--- a/gw_spaceheat/helpers.py
+++ b/gw_spaceheat/helpers.py
@@ -5,9 +5,6 @@ import time
 import pendulum
 from dotenv import load_dotenv
 
-import settings
-
-
 snake_add_underscore_to_camel_pattern = re.compile(r"(?<!^)(?=[A-Z])")
 
 
@@ -23,18 +20,6 @@ def get_secret(key):
     elif value == "None":
         return None
     return value
-
-
-def atn_g_node_alias():
-    return settings.ATN_G_NODE_ALIAS
-
-
-def scada_g_node_alias():
-    return f"{settings.ATN_G_NODE_ALIAS}.ta.scada"
-
-
-def ta_g_node_alias():
-    return f"{settings.ATN_G_NODE_ALIAS}.ta"
 
 
 def log_time() -> str:

--- a/gw_spaceheat/input_data/houses.json
+++ b/gw_spaceheat/input_data/houses.json
@@ -1,6 +1,30 @@
 {    
-    "w.isone.nh.orange.1":
+    "w":
     {
+        "MyAtomicTNodeGNode":
+        {
+            "GNodeId": "d636cbeb-c4ad-45cd-b5bc-1c64cc33f4f4",
+            "Alias": "w.isone.ct.newhaven.orange1",
+            "DisplayName": "Little Orange House Garage Heating System AtomicTNode",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "AtomicTNode"
+        },
+        "MyTerminalAssetGNode": 
+          {
+              "GNodeId": "137d7f06-ea65-4254-bfd1-5d56fa789229",
+              "Alias":  "w.isone.ct.newhaven.orange1.ta",
+              "DisplayName": "Little Orange House Garage Heating System TerminalAsset",
+              "GNodeStatusValue": "Active",
+              "PrimaryGNodeRoleAlias": "TerminalAsset"
+        },
+        "MyScadaGNode": 
+        {
+            "GNodeId": "28817671-3899-4e24-a337-abcb8633e47a",
+            "Alias":  "w.isone.ct.newhaven.orange1.ta.scada",
+            "DisplayName": "Little Orange House Garage Heating System SCADA",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "Scada"
+        },
         "ShNodes": [
             {
                 "Alias": "a",
@@ -429,8 +453,31 @@
             }
         ]     
     },
-    "dwjess.isone.nh.orange.1":
+    "dwjess":
     {
+        "MyAtomicTNodeGNode":{
+            "GNodeId": "c4c9a280-453f-4c36-a081-970a3774b3ed",
+            "Alias": "dwjess.isone.ct.newhaven.orange1",
+            "DisplayName": "Little Orange House Garage Heating System AtomicTNode",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "AtomicTNode"
+        },
+        "MyTerminalAssetGNode": 
+        {
+            "GNodeId": "e250a99c-7b7f-469a-8f54-96ea83e95112",
+            "Alias":  "dwjess.isone.ct.newhaven.orange1.ta",
+            "DisplayName": "Little Orange House Garage Heating System TerminalAsset",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "TerminalAsset"
+        },
+        "MyScadaGNode":
+        {
+            "GNodeId": "c9794c6d-e013-4d74-9570-f9ba4b0f0b0d",
+            "Alias":  "dwjess.isone.ct.newhaven.orange1.ta.scada",
+            "DisplayName": "Little Orange House Garage Heating System SCADA",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "Scada"
+        },
         "ShNodes": [
             {
                 "Alias": "a",
@@ -915,8 +962,32 @@
             }
         ]
     },
-    "dwandy.isone.nh.orange.1":
+    "dwandy":
     {
+        "MyAtomicTNodeGNode":
+        {
+            "GNodeId": "4ba1d7b2-f0df-4c89-9cc3-0ff421c2e628",
+            "Alias":  "dwandy.isone.ct.newhaven.orange1",
+            "DisplayName": "Little Orange House Garage Heating System Atomic TNode",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "AtomicTNode"
+        },
+        "MyTerminalAssetGNode": 
+        {
+            "GNodeId": "9c70f83a-f4bf-46c0-992e-73d5e60bfa1a",
+            "Alias":  "dwandy.isone.ct.newhaven.orange1.ta",
+            "DisplayName": "Little Orange House Garage Heating System TerminalAsset",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "TerminalAsset"
+        },
+        "MyScadaGNode": 
+        {
+            "GNodeId": "e76f771b-4cc7-403c-8355-c293745eb559",
+            "Alias": "dwandy.isone.ct.newhaven.orange1.ta.scada",
+            "DisplayName": "Little Orange House Garage Heating System SCADA",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "Scada"
+        },
         "ShNodes": [
             {
                 "Alias": "a",
@@ -1401,8 +1472,32 @@
             }
         ]
     },
-    "dwtest.isone.nh.orange.1":
+    "dwtest":
     {
+        "MyAtomicTNodeGNode":
+        {
+            "GNodeId": "e7f7d6cc-08b0-4b36-bbbb-0a1f8447fd32",
+            "Alias":  "dwtest.isone.ct.newhaven.orange1",
+            "DisplayName": "Little Orange House Garage Heating System AtomicTNode",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "AtomicTNode"
+        },
+        "MyTerminalAssetGNode": 
+        {
+            "GNodeId": "851670de-3ddf-407e-a1ff-3d366ee57f61",
+            "Alias":  "dwtest.isone.ct.newhaven.orange1.ta",
+            "DisplayName": "Little Orange House Garage Heating System TerminalAsset",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "TerminalAsset"
+        },
+        "MyScadaGNode":
+        {
+            "GNodeId": "0384ef21-648b-4455-b917-58a1172d7fc1",
+            "Alias": "dwtest.isone.ct.newhaven.orange1.ta.scada",
+            "DisplayName": "Little Orange House Garage Heating System SCADA",
+            "GNodeStatusValue": "Active",
+            "PrimaryGNodeRoleAlias": "Scada"
+        },
         "ShNodes": [
             {
                 "Alias": "a",

--- a/gw_spaceheat/load_house.py
+++ b/gw_spaceheat/load_house.py
@@ -70,13 +70,13 @@ def load_nodes(house_data):
         GtShNode_Maker.dict_to_dc(d)
 
 
-def load_all(atn_g_node_alias=settings.ATN_G_NODE_ALIAS):
+def load_all(world_root_alias=settings.WORLD_ROOT_ALIAS):
     current_dir = os.path.dirname(os.path.realpath(__file__))
     with open(os.path.join(current_dir, "input_data/houses.json"), "r") as read_file:
         input_data = json.load(read_file)
-    if atn_g_node_alias not in input_data.keys():
-        raise Exception(f"{atn_g_node_alias} house data missing from input_data/houses.json")
-    house_data = input_data[atn_g_node_alias]
+    if world_root_alias not in input_data.keys():
+        raise Exception(f"{world_root_alias} house data missing from input_data/houses.json")
+    house_data = input_data[world_root_alias]
     load_cacs(house_data=house_data)
     load_components(house_data=house_data)
     load_nodes(house_data=house_data)

--- a/gw_spaceheat/schema/gt/gt_dispatch_boolean/gt_dispatch_boolean.py
+++ b/gw_spaceheat/schema/gt/gt_dispatch_boolean/gt_dispatch_boolean.py
@@ -1,17 +1,17 @@
-"""gt.dispatch.110 type"""
+"""gt.dispatch.boolean.100 type"""
 
 from schema.errors import MpSchemaError
-from schema.gt.gt_dispatch.gt_dispatch_base import (
-    GtDispatchBase,
+from schema.gt.gt_dispatch_boolean.gt_dispatch_boolean_base import (
+    GtDispatchBooleanBase,
 )
 
 
-class GtDispatch(GtDispatchBase):
+class GtDispatchBoolean(GtDispatchBooleanBase):
     def check_for_errors(self):
         errors = self.derived_errors() + self.hand_coded_errors()
         if len(errors) > 0:
             raise MpSchemaError(
-                f" Errors making making gt.dispatch.110 for {self}: {errors}"
+                f" Errors making making gt.dispatch.boolean.100 for {self}: {errors}"
             )
 
     def hand_coded_errors(self):

--- a/gw_spaceheat/schema/gt/gt_dispatch_boolean/gt_dispatch_boolean_base.py
+++ b/gw_spaceheat/schema/gt/gt_dispatch_boolean/gt_dispatch_boolean_base.py
@@ -1,0 +1,84 @@
+"""Base for gt.dispatch.boolean.100"""
+import json
+from typing import List, NamedTuple
+import schema.property_format as property_format
+
+
+class GtDispatchBooleanBase(NamedTuple):
+    AboutNodeAlias: str  #
+    ToGNodeAlias: str  #
+    FromGNodeAlias: str  #
+    FromGNodeId: str  #
+    RelayState: int  #
+    SendTimeUnixMs: int  #
+    TypeAlias: str = "gt.dispatch.boolean.100"
+
+    def as_type(self):
+        return json.dumps(self.asdict())
+
+    def asdict(self):
+        d = self._asdict()
+        return d
+
+    def derived_errors(self) -> List[str]:
+        errors = []
+        if not isinstance(self.AboutNodeAlias, str):
+            errors.append(
+                f"AboutNodeAlias {self.AboutNodeAlias} must have type str."
+            )
+        if not property_format.is_lrd_alias_format(self.AboutNodeAlias):
+            errors.append(
+                f"AboutNodeAlias {self.AboutNodeAlias}"
+                " must have format LrdAliasFormat"
+            )
+        if not isinstance(self.ToGNodeAlias, str):
+            errors.append(
+                f"ToGNodeAlias {self.ToGNodeAlias} must have type str."
+            )
+        if not property_format.is_lrd_alias_format(self.ToGNodeAlias):
+            errors.append(
+                f"ToGNodeAlias {self.ToGNodeAlias}"
+                " must have format LrdAliasFormat"
+            )
+        if not isinstance(self.FromGNodeAlias, str):
+            errors.append(
+                f"FromGNodeAlias {self.FromGNodeAlias} must have type str."
+            )
+        if not property_format.is_lrd_alias_format(self.FromGNodeAlias):
+            errors.append(
+                f"FromGNodeAlias {self.FromGNodeAlias}"
+                " must have format LrdAliasFormat"
+            )
+        if not isinstance(self.FromGNodeId, str):
+            errors.append(
+                f"FromGNodeId {self.FromGNodeId} must have type str."
+            )
+        if not property_format.is_uuid_canonical_textual(self.FromGNodeId):
+            errors.append(
+                f"FromGNodeId {self.FromGNodeId}"
+                " must have format UuidCanonicalTextual"
+            )
+        if not isinstance(self.RelayState, int):
+            errors.append(
+                f"RelayState {self.RelayState} must have type int."
+            )
+        if not property_format.is_bit(self.RelayState):
+            errors.append(
+                f"RelayState {self.RelayState}"
+                " must have format Bit"
+            )
+        if not isinstance(self.SendTimeUnixMs, int):
+            errors.append(
+                f"SendTimeUnixMs {self.SendTimeUnixMs} must have type int."
+            )
+        if not property_format.is_reasonable_unix_time_ms(self.SendTimeUnixMs):
+            errors.append(
+                f"SendTimeUnixMs {self.SendTimeUnixMs}"
+                " must have format ReasonableUnixTimeMs"
+            )
+        if self.TypeAlias != "gt.dispatch.boolean.100":
+            errors.append(
+                f"Type requires TypeAlias of gt.dispatch.boolean.100, not {self.TypeAlias}."
+            )
+
+        return errors

--- a/gw_spaceheat/schema/gt/gt_dispatch_boolean/gt_dispatch_boolean_maker.py
+++ b/gw_spaceheat/schema/gt/gt_dispatch_boolean/gt_dispatch_boolean_maker.py
@@ -1,0 +1,77 @@
+"""Makes gt.dispatch.boolean.100 type"""
+import json
+
+from schema.gt.gt_dispatch_boolean.gt_dispatch_boolean import GtDispatchBoolean
+from schema.errors import MpSchemaError
+
+
+class GtDispatchBoolean_Maker:
+    type_alias = "gt.dispatch.boolean.100"
+
+    def __init__(self,
+                 about_node_alias: str,
+                 to_g_node_alias: str,
+                 from_g_node_alias: str,
+                 from_g_node_id: str,
+                 relay_state: int,
+                 send_time_unix_ms: int):
+
+        gw_tuple = GtDispatchBoolean(
+            AboutNodeAlias=about_node_alias,
+            ToGNodeAlias=to_g_node_alias,
+            FromGNodeAlias=from_g_node_alias,
+            FromGNodeId=from_g_node_id,
+            RelayState=relay_state,
+            SendTimeUnixMs=send_time_unix_ms,
+            #
+        )
+        gw_tuple.check_for_errors()
+        self.tuple = gw_tuple
+
+    @classmethod
+    def tuple_to_type(cls, tuple: GtDispatchBoolean) -> str:
+        tuple.check_for_errors()
+        return tuple.as_type()
+
+    @classmethod
+    def type_to_tuple(cls, t: str) -> GtDispatchBoolean:
+        try:
+            d = json.loads(t)
+        except TypeError:
+            raise MpSchemaError("Type must be string or bytes!")
+        if not isinstance(d, dict):
+            raise MpSchemaError(f"Deserializing {t} must result in dict!")
+        return cls.dict_to_tuple(d)
+
+    @classmethod
+    def dict_to_tuple(cls, d: dict) -> GtDispatchBoolean:
+        new_d = {}
+        for key in d.keys():
+            new_d[key] = d[key]
+        if "TypeAlias" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing TypeAlias")
+        if "AboutNodeAlias" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing AboutNodeAlias")
+        if "ToGNodeAlias" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing ToGNodeAlias")
+        if "FromGNodeAlias" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing FromGNodeAlias")
+        if "FromGNodeId" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing FromGNodeId")
+        if "RelayState" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing RelayState")
+        if "SendTimeUnixMs" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing SendTimeUnixMs")
+
+        gw_tuple = GtDispatchBoolean(
+            TypeAlias=new_d["TypeAlias"],
+            AboutNodeAlias=new_d["AboutNodeAlias"],
+            ToGNodeAlias=new_d["ToGNodeAlias"],
+            FromGNodeAlias=new_d["FromGNodeAlias"],
+            FromGNodeId=new_d["FromGNodeId"],
+            RelayState=new_d["RelayState"],
+            SendTimeUnixMs=new_d["SendTimeUnixMs"],
+            #
+        )
+        gw_tuple.check_for_errors()
+        return gw_tuple

--- a/gw_spaceheat/schema/gt/gt_dispatch_boolean_local/gt_dispatch_boolean_local.py
+++ b/gw_spaceheat/schema/gt/gt_dispatch_boolean_local/gt_dispatch_boolean_local.py
@@ -1,0 +1,18 @@
+"""gt.dispatch.boolean.local.100 type"""
+
+from schema.errors import MpSchemaError
+from schema.gt.gt_dispatch_boolean_local.gt_dispatch_boolean_local_base import (
+    GtDispatchBooleanLocalBase,
+)
+
+
+class GtDispatchBooleanLocal(GtDispatchBooleanLocalBase):
+    def check_for_errors(self):
+        errors = self.derived_errors() + self.hand_coded_errors()
+        if len(errors) > 0:
+            raise MpSchemaError(
+                f" Errors making making gt.dispatch.boolean.local.100 for {self}: {errors}"
+            )
+
+    def hand_coded_errors(self):
+        return []

--- a/gw_spaceheat/schema/gt/gt_dispatch_boolean_local/gt_dispatch_boolean_local_base.py
+++ b/gw_spaceheat/schema/gt/gt_dispatch_boolean_local/gt_dispatch_boolean_local_base.py
@@ -1,14 +1,15 @@
-"""Base for gt.dispatch.110"""
+"""Base for gt.dispatch.boolean.local.100"""
 import json
 from typing import List, NamedTuple
 import schema.property_format as property_format
 
 
-class GtDispatchBase(NamedTuple):
-    ShNodeAlias: str  #
+class GtDispatchBooleanLocalBase(NamedTuple):
     SendTimeUnixMs: int  #
+    FromNodeAlias: str  #
+    AboutNodeAlias: str  #
     RelayState: int  #
-    TypeAlias: str = "gt.dispatch.110"
+    TypeAlias: str = "gt.dispatch.boolean.local.100"
 
     def as_type(self):
         return json.dumps(self.asdict())
@@ -19,15 +20,6 @@ class GtDispatchBase(NamedTuple):
 
     def derived_errors(self) -> List[str]:
         errors = []
-        if not isinstance(self.ShNodeAlias, str):
-            errors.append(
-                f"ShNodeAlias {self.ShNodeAlias} must have type str."
-            )
-        if not property_format.is_lrd_alias_format(self.ShNodeAlias):
-            errors.append(
-                f"ShNodeAlias {self.ShNodeAlias}"
-                " must have format LrdAliasFormat"
-            )
         if not isinstance(self.SendTimeUnixMs, int):
             errors.append(
                 f"SendTimeUnixMs {self.SendTimeUnixMs} must have type int."
@@ -36,6 +28,24 @@ class GtDispatchBase(NamedTuple):
             errors.append(
                 f"SendTimeUnixMs {self.SendTimeUnixMs}"
                 " must have format ReasonableUnixTimeMs"
+            )
+        if not isinstance(self.FromNodeAlias, str):
+            errors.append(
+                f"FromNodeAlias {self.FromNodeAlias} must have type str."
+            )
+        if not property_format.is_lrd_alias_format(self.FromNodeAlias):
+            errors.append(
+                f"FromNodeAlias {self.FromNodeAlias}"
+                " must have format LrdAliasFormat"
+            )
+        if not isinstance(self.AboutNodeAlias, str):
+            errors.append(
+                f"AboutNodeAlias {self.AboutNodeAlias} must have type str."
+            )
+        if not property_format.is_lrd_alias_format(self.AboutNodeAlias):
+            errors.append(
+                f"AboutNodeAlias {self.AboutNodeAlias}"
+                " must have format LrdAliasFormat"
             )
         if not isinstance(self.RelayState, int):
             errors.append(
@@ -46,9 +56,9 @@ class GtDispatchBase(NamedTuple):
                 f"RelayState {self.RelayState}"
                 " must have format Bit"
             )
-        if self.TypeAlias != "gt.dispatch.110":
+        if self.TypeAlias != "gt.dispatch.boolean.local.100":
             errors.append(
-                f"Type requires TypeAlias of gt.dispatch.110, not {self.TypeAlias}."
+                f"Type requires TypeAlias of gt.dispatch.boolean.local.100, not {self.TypeAlias}."
             )
 
         return errors

--- a/gw_spaceheat/schema/gt/gt_dispatch_boolean_local/gt_dispatch_boolean_local_maker.py
+++ b/gw_spaceheat/schema/gt/gt_dispatch_boolean_local/gt_dispatch_boolean_local_maker.py
@@ -1,21 +1,23 @@
-"""Makes gt.dispatch.110 type"""
+"""Makes gt.dispatch.boolean.local.100 type"""
 import json
 
-from schema.gt.gt_dispatch.gt_dispatch import GtDispatch
+from schema.gt.gt_dispatch_boolean_local.gt_dispatch_boolean_local import GtDispatchBooleanLocal
 from schema.errors import MpSchemaError
 
 
-class GtDispatch_Maker:
-    type_alias = "gt.dispatch.110"
+class GtDispatchBooleanLocal_Maker:
+    type_alias = "gt.dispatch.boolean.local.100"
 
     def __init__(self,
-                 sh_node_alias: str,
                  send_time_unix_ms: int,
+                 from_node_alias: str,
+                 about_node_alias: str,
                  relay_state: int):
 
-        gw_tuple = GtDispatch(
-            ShNodeAlias=sh_node_alias,
+        gw_tuple = GtDispatchBooleanLocal(
             SendTimeUnixMs=send_time_unix_ms,
+            FromNodeAlias=from_node_alias,
+            AboutNodeAlias=about_node_alias,
             RelayState=relay_state,
             #
         )
@@ -23,12 +25,12 @@ class GtDispatch_Maker:
         self.tuple = gw_tuple
 
     @classmethod
-    def tuple_to_type(cls, tuple: GtDispatch) -> str:
+    def tuple_to_type(cls, tuple: GtDispatchBooleanLocal) -> str:
         tuple.check_for_errors()
         return tuple.as_type()
 
     @classmethod
-    def type_to_tuple(cls, t: str) -> GtDispatch:
+    def type_to_tuple(cls, t: str) -> GtDispatchBooleanLocal:
         try:
             d = json.loads(t)
         except TypeError:
@@ -38,23 +40,26 @@ class GtDispatch_Maker:
         return cls.dict_to_tuple(d)
 
     @classmethod
-    def dict_to_tuple(cls, d: dict) -> GtDispatch:
+    def dict_to_tuple(cls, d: dict) -> GtDispatchBooleanLocal:
         new_d = {}
         for key in d.keys():
             new_d[key] = d[key]
         if "TypeAlias" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing TypeAlias")
-        if "ShNodeAlias" not in new_d.keys():
-            raise MpSchemaError(f"dict {new_d} missing ShNodeAlias")
         if "SendTimeUnixMs" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing SendTimeUnixMs")
+        if "FromNodeAlias" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing FromNodeAlias")
+        if "AboutNodeAlias" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing AboutNodeAlias")
         if "RelayState" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing RelayState")
 
-        gw_tuple = GtDispatch(
+        gw_tuple = GtDispatchBooleanLocal(
             TypeAlias=new_d["TypeAlias"],
-            ShNodeAlias=new_d["ShNodeAlias"],
             SendTimeUnixMs=new_d["SendTimeUnixMs"],
+            FromNodeAlias=new_d["FromNodeAlias"],
+            AboutNodeAlias=new_d["AboutNodeAlias"],
             RelayState=new_d["RelayState"],
             #
         )

--- a/gw_spaceheat/schema/gt/gt_sh_cli_atn_cmd/gt_sh_cli_atn_cmd.py
+++ b/gw_spaceheat/schema/gt/gt_sh_cli_atn_cmd/gt_sh_cli_atn_cmd.py
@@ -1,4 +1,4 @@
-"""gt.sh.cli.atn.cmd.100 type"""
+"""gt.sh.cli.atn.cmd.110 type"""
 
 from schema.errors import MpSchemaError
 from schema.gt.gt_sh_cli_atn_cmd.gt_sh_cli_atn_cmd_base import (
@@ -11,7 +11,7 @@ class GtShCliAtnCmd(GtShCliAtnCmdBase):
         errors = self.derived_errors() + self.hand_coded_errors()
         if len(errors) > 0:
             raise MpSchemaError(
-                f" Errors making making gt.sh.cli.atn.cmd.100 for {self}: {errors}"
+                f" Errors making making gt.sh.cli.atn.cmd.110 for {self}: {errors}"
             )
 
     def hand_coded_errors(self):

--- a/gw_spaceheat/schema/gt/gt_sh_cli_atn_cmd/gt_sh_cli_atn_cmd_base.py
+++ b/gw_spaceheat/schema/gt/gt_sh_cli_atn_cmd/gt_sh_cli_atn_cmd_base.py
@@ -1,11 +1,14 @@
-"""Base for gt.sh.cli.atn.cmd.100"""
+"""Base for gt.sh.cli.atn.cmd.110"""
 import json
 from typing import List, NamedTuple
+import schema.property_format as property_format
 
 
 class GtShCliAtnCmdBase(NamedTuple):
+    FromGNodeAlias: str  #
     SendSnapshot: bool  #
-    TypeAlias: str = "gt.sh.cli.atn.cmd.100"
+    FromGNodeId: str  #
+    TypeAlias: str = "gt.sh.cli.atn.cmd.110"
 
     def as_type(self):
         return json.dumps(self.asdict())
@@ -16,13 +19,31 @@ class GtShCliAtnCmdBase(NamedTuple):
 
     def derived_errors(self) -> List[str]:
         errors = []
+        if not isinstance(self.FromGNodeAlias, str):
+            errors.append(
+                f"FromGNodeAlias {self.FromGNodeAlias} must have type str."
+            )
+        if not property_format.is_lrd_alias_format(self.FromGNodeAlias):
+            errors.append(
+                f"FromGNodeAlias {self.FromGNodeAlias}"
+                " must have format LrdAliasFormat"
+            )
         if not isinstance(self.SendSnapshot, bool):
             errors.append(
                 f"SendSnapshot {self.SendSnapshot} must have type bool."
             )
-        if self.TypeAlias != "gt.sh.cli.atn.cmd.100":
+        if not isinstance(self.FromGNodeId, str):
             errors.append(
-                f"Type requires TypeAlias of gt.sh.cli.atn.cmd.100, not {self.TypeAlias}."
+                f"FromGNodeId {self.FromGNodeId} must have type str."
+            )
+        if not property_format.is_uuid_canonical_textual(self.FromGNodeId):
+            errors.append(
+                f"FromGNodeId {self.FromGNodeId}"
+                " must have format UuidCanonicalTextual"
+            )
+        if self.TypeAlias != "gt.sh.cli.atn.cmd.110":
+            errors.append(
+                f"Type requires TypeAlias of gt.sh.cli.atn.cmd.110, not {self.TypeAlias}."
             )
 
         return errors

--- a/gw_spaceheat/schema/gt/gt_sh_cli_atn_cmd/gt_sh_cli_atn_cmd_maker.py
+++ b/gw_spaceheat/schema/gt/gt_sh_cli_atn_cmd/gt_sh_cli_atn_cmd_maker.py
@@ -1,4 +1,4 @@
-"""Makes gt.sh.cli.atn.cmd.100 type"""
+"""Makes gt.sh.cli.atn.cmd.110 type"""
 import json
 
 from schema.gt.gt_sh_cli_atn_cmd.gt_sh_cli_atn_cmd import GtShCliAtnCmd
@@ -6,13 +6,17 @@ from schema.errors import MpSchemaError
 
 
 class GtShCliAtnCmd_Maker:
-    type_alias = "gt.sh.cli.atn.cmd.100"
+    type_alias = "gt.sh.cli.atn.cmd.110"
 
     def __init__(self,
-                 send_snapshot: bool):
+                 from_g_node_alias: str,
+                 send_snapshot: bool,
+                 from_g_node_id: str):
 
         gw_tuple = GtShCliAtnCmd(
+            FromGNodeAlias=from_g_node_alias,
             SendSnapshot=send_snapshot,
+            FromGNodeId=from_g_node_id,
             #
         )
         gw_tuple.check_for_errors()
@@ -40,12 +44,18 @@ class GtShCliAtnCmd_Maker:
             new_d[key] = d[key]
         if "TypeAlias" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing TypeAlias")
+        if "FromGNodeAlias" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing FromGNodeAlias")
         if "SendSnapshot" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing SendSnapshot")
+        if "FromGNodeId" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing FromGNodeId")
 
         gw_tuple = GtShCliAtnCmd(
             TypeAlias=new_d["TypeAlias"],
+            FromGNodeAlias=new_d["FromGNodeAlias"],
             SendSnapshot=new_d["SendSnapshot"],
+            FromGNodeId=new_d["FromGNodeId"],
             #
         )
         gw_tuple.check_for_errors()

--- a/gw_spaceheat/schema/gt/gt_sh_cli_scada_response/gt_sh_cli_scada_response.py
+++ b/gw_spaceheat/schema/gt/gt_sh_cli_scada_response/gt_sh_cli_scada_response.py
@@ -1,4 +1,4 @@
-"""gt.sh.cli.scada.response.100 type"""
+"""gt.sh.cli.scada.response.110 type"""
 
 from schema.errors import MpSchemaError
 from schema.gt.gt_sh_cli_scada_response.gt_sh_cli_scada_response_base import (
@@ -11,7 +11,7 @@ class GtShCliScadaResponse(GtShCliScadaResponseBase):
         errors = self.derived_errors() + self.hand_coded_errors()
         if len(errors) > 0:
             raise MpSchemaError(
-                f" Errors making making gt.sh.cli.scada.response.100 for {self}: {errors}"
+                f" Errors making making gt.sh.cli.scada.response.110 for {self}: {errors}"
             )
 
     def hand_coded_errors(self):

--- a/gw_spaceheat/schema/gt/gt_sh_cli_scada_response/gt_sh_cli_scada_response_base.py
+++ b/gw_spaceheat/schema/gt/gt_sh_cli_scada_response/gt_sh_cli_scada_response_base.py
@@ -1,12 +1,15 @@
-"""Base for gt.sh.cli.scada.response.100"""
+"""Base for gt.sh.cli.scada.response.110"""
 import json
 from typing import List, NamedTuple
+import schema.property_format as property_format
 from schema.gt.gt_sh_status_snapshot.gt_sh_status_snapshot_maker import GtShStatusSnapshot
 
 
 class GtShCliScadaResponseBase(NamedTuple):
+    FromGNodeAlias: str  #
+    FromGNodeId: str  #
     Snapshot: GtShStatusSnapshot  #
-    TypeAlias: str = "gt.sh.cli.scada.response.100"
+    TypeAlias: str = "gt.sh.cli.scada.response.110"
 
     def as_type(self):
         return json.dumps(self.asdict())
@@ -18,13 +21,31 @@ class GtShCliScadaResponseBase(NamedTuple):
 
     def derived_errors(self) -> List[str]:
         errors = []
+        if not isinstance(self.FromGNodeAlias, str):
+            errors.append(
+                f"FromGNodeAlias {self.FromGNodeAlias} must have type str."
+            )
+        if not property_format.is_lrd_alias_format(self.FromGNodeAlias):
+            errors.append(
+                f"FromGNodeAlias {self.FromGNodeAlias}"
+                " must have format LrdAliasFormat"
+            )
+        if not isinstance(self.FromGNodeId, str):
+            errors.append(
+                f"FromGNodeId {self.FromGNodeId} must have type str."
+            )
+        if not property_format.is_uuid_canonical_textual(self.FromGNodeId):
+            errors.append(
+                f"FromGNodeId {self.FromGNodeId}"
+                " must have format UuidCanonicalTextual"
+            )
         if not isinstance(self.Snapshot, GtShStatusSnapshot):
             errors.append(
                 f"Snapshot {self.Snapshot} must have typeGtShStatusSnapshot."
             )
-        if self.TypeAlias != "gt.sh.cli.scada.response.100":
+        if self.TypeAlias != "gt.sh.cli.scada.response.110":
             errors.append(
-                f"Type requires TypeAlias of gt.sh.cli.scada.response.100, not {self.TypeAlias}."
+                f"Type requires TypeAlias of gt.sh.cli.scada.response.110, not {self.TypeAlias}."
             )
 
         return errors

--- a/gw_spaceheat/schema/gt/gt_sh_cli_scada_response/gt_sh_cli_scada_response_maker.py
+++ b/gw_spaceheat/schema/gt/gt_sh_cli_scada_response/gt_sh_cli_scada_response_maker.py
@@ -1,4 +1,4 @@
-"""Makes gt.sh.cli.scada.response.100 type"""
+"""Makes gt.sh.cli.scada.response.110 type"""
 import json
 
 from schema.gt.gt_sh_cli_scada_response.gt_sh_cli_scada_response import GtShCliScadaResponse
@@ -10,12 +10,16 @@ from schema.gt.gt_sh_status_snapshot.gt_sh_status_snapshot_maker import (
 
 
 class GtShCliScadaResponse_Maker:
-    type_alias = "gt.sh.cli.scada.response.100"
+    type_alias = "gt.sh.cli.scada.response.110"
 
     def __init__(self,
+                 from_g_node_alias: str,
+                 from_g_node_id: str,
                  snapshot: GtShStatusSnapshot):
 
         gw_tuple = GtShCliScadaResponse(
+            FromGNodeAlias=from_g_node_alias,
+            FromGNodeId=from_g_node_id,
             Snapshot=snapshot,
             #
         )
@@ -44,6 +48,10 @@ class GtShCliScadaResponse_Maker:
             new_d[key] = d[key]
         if "TypeAlias" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing TypeAlias")
+        if "FromGNodeAlias" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing FromGNodeAlias")
+        if "FromGNodeId" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing FromGNodeId")
         if "Snapshot" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing Snapshot")
         if not isinstance(new_d["Snapshot"], dict):
@@ -53,6 +61,8 @@ class GtShCliScadaResponse_Maker:
 
         gw_tuple = GtShCliScadaResponse(
             TypeAlias=new_d["TypeAlias"],
+            FromGNodeAlias=new_d["FromGNodeAlias"],
+            FromGNodeId=new_d["FromGNodeId"],
             Snapshot=new_d["Snapshot"],
             #
         )

--- a/gw_spaceheat/schema/gt/gt_sh_status/gt_sh_status.py
+++ b/gw_spaceheat/schema/gt/gt_sh_status/gt_sh_status.py
@@ -1,4 +1,4 @@
-"""gt.sh.status.100 type"""
+"""gt.sh.status.110 type"""
 
 from schema.errors import MpSchemaError
 from schema.gt.gt_sh_status.gt_sh_status_base import (
@@ -11,7 +11,7 @@ class GtShStatus(GtShStatusBase):
         errors = self.derived_errors() + self.hand_coded_errors()
         if len(errors) > 0:
             raise MpSchemaError(
-                f" Errors making making gt.sh.status.100 for {self}: {errors}"
+                f" Errors making making gt.sh.status.110 for {self}: {errors}"
             )
 
     def hand_coded_errors(self):

--- a/gw_spaceheat/schema/gt/gt_sh_status/gt_sh_status_base.py
+++ b/gw_spaceheat/schema/gt/gt_sh_status/gt_sh_status_base.py
@@ -1,20 +1,23 @@
-"""Base for gt.sh.status.100"""
+"""Base for gt.sh.status.110"""
 import json
 from typing import List, NamedTuple
 import schema.property_format as property_format
-from schema.gt.gt_sh_booleanactuator_cmd_status.gt_sh_booleanactuator_cmd_status_maker import GtShBooleanactuatorCmdStatus
 from schema.gt.gt_sh_simple_telemetry_status.gt_sh_simple_telemetry_status_maker import GtShSimpleTelemetryStatus
+from schema.gt.gt_sh_booleanactuator_cmd_status.gt_sh_booleanactuator_cmd_status_maker import GtShBooleanactuatorCmdStatus
 from schema.gt.gt_sh_multipurpose_telemetry_status.gt_sh_multipurpose_telemetry_status_maker import GtShMultipurposeTelemetryStatus
 
 
 class GtShStatusBase(NamedTuple):
-    BooleanactuatorCmdList: List[GtShBooleanactuatorCmdStatus]
-    SimpleTelemetryList: List[GtShSimpleTelemetryStatus]
-    MultipurposeTelemetryList: List[GtShMultipurposeTelemetryStatus]
     SlotStartUnixS: int  #
+    SimpleTelemetryList: List[GtShSimpleTelemetryStatus]
     AboutGNodeAlias: str  #
+    BooleanactuatorCmdList: List[GtShBooleanactuatorCmdStatus]
+    FromGNodeAlias: str  #
+    MultipurposeTelemetryList: List[GtShMultipurposeTelemetryStatus]
+    FromGNodeId: str  #
+    StatusUid: str  #
     ReportingPeriodS: int  #
-    TypeAlias: str = "gt.sh.status.100"
+    TypeAlias: str = "gt.sh.status.110"
 
     def as_type(self):
         return json.dumps(self.asdict())
@@ -23,16 +26,16 @@ class GtShStatusBase(NamedTuple):
         d = self._asdict()
 
         # Recursively call asdict() for the SubTypes
-        booleanactuator_cmd_list = []
-        for elt in self.BooleanactuatorCmdList:
-            booleanactuator_cmd_list.append(elt.asdict())
-        d["BooleanactuatorCmdList"] = booleanactuator_cmd_list
-
-        # Recursively call asdict() for the SubTypes
         simple_telemetry_list = []
         for elt in self.SimpleTelemetryList:
             simple_telemetry_list.append(elt.asdict())
         d["SimpleTelemetryList"] = simple_telemetry_list
+
+        # Recursively call asdict() for the SubTypes
+        booleanactuator_cmd_list = []
+        for elt in self.BooleanactuatorCmdList:
+            booleanactuator_cmd_list.append(elt.asdict())
+        d["BooleanactuatorCmdList"] = booleanactuator_cmd_list
 
         # Recursively call asdict() for the SubTypes
         multipurpose_telemetry_list = []
@@ -43,16 +46,15 @@ class GtShStatusBase(NamedTuple):
 
     def derived_errors(self) -> List[str]:
         errors = []
-        if not isinstance(self.BooleanactuatorCmdList, list):
+        if not isinstance(self.SlotStartUnixS, int):
             errors.append(
-                f"BooleanactuatorCmdList {self.BooleanactuatorCmdList} must have type list."
+                f"SlotStartUnixS {self.SlotStartUnixS} must have type int."
             )
-        else:
-            for elt in self.BooleanactuatorCmdList:
-                if not isinstance(elt, GtShBooleanactuatorCmdStatus):
-                    errors.append(
-                        f"elt {elt} of BooleanactuatorCmdList must have type GtShBooleanactuatorCmdStatus."
-                    )
+        if not property_format.is_reasonable_unix_time_s(self.SlotStartUnixS):
+            errors.append(
+                f"SlotStartUnixS {self.SlotStartUnixS}"
+                " must have format ReasonableUnixTimeS"
+            )
         if not isinstance(self.SimpleTelemetryList, list):
             errors.append(
                 f"SimpleTelemetryList {self.SimpleTelemetryList} must have type list."
@@ -63,6 +65,34 @@ class GtShStatusBase(NamedTuple):
                     errors.append(
                         f"elt {elt} of SimpleTelemetryList must have type GtShSimpleTelemetryStatus."
                     )
+        if not isinstance(self.AboutGNodeAlias, str):
+            errors.append(
+                f"AboutGNodeAlias {self.AboutGNodeAlias} must have type str."
+            )
+        if not property_format.is_lrd_alias_format(self.AboutGNodeAlias):
+            errors.append(
+                f"AboutGNodeAlias {self.AboutGNodeAlias}"
+                " must have format LrdAliasFormat"
+            )
+        if not isinstance(self.BooleanactuatorCmdList, list):
+            errors.append(
+                f"BooleanactuatorCmdList {self.BooleanactuatorCmdList} must have type list."
+            )
+        else:
+            for elt in self.BooleanactuatorCmdList:
+                if not isinstance(elt, GtShBooleanactuatorCmdStatus):
+                    errors.append(
+                        f"elt {elt} of BooleanactuatorCmdList must have type GtShBooleanactuatorCmdStatus."
+                    )
+        if not isinstance(self.FromGNodeAlias, str):
+            errors.append(
+                f"FromGNodeAlias {self.FromGNodeAlias} must have type str."
+            )
+        if not property_format.is_lrd_alias_format(self.FromGNodeAlias):
+            errors.append(
+                f"FromGNodeAlias {self.FromGNodeAlias}"
+                " must have format LrdAliasFormat"
+            )
         if not isinstance(self.MultipurposeTelemetryList, list):
             errors.append(
                 f"MultipurposeTelemetryList {self.MultipurposeTelemetryList} must have type list."
@@ -73,31 +103,31 @@ class GtShStatusBase(NamedTuple):
                     errors.append(
                         f"elt {elt} of MultipurposeTelemetryList must have type GtShMultipurposeTelemetryStatus."
                     )
-        if not isinstance(self.SlotStartUnixS, int):
+        if not isinstance(self.FromGNodeId, str):
             errors.append(
-                f"SlotStartUnixS {self.SlotStartUnixS} must have type int."
+                f"FromGNodeId {self.FromGNodeId} must have type str."
             )
-        if not property_format.is_reasonable_unix_time_s(self.SlotStartUnixS):
+        if not property_format.is_uuid_canonical_textual(self.FromGNodeId):
             errors.append(
-                f"SlotStartUnixS {self.SlotStartUnixS}"
-                " must have format ReasonableUnixTimeS"
+                f"FromGNodeId {self.FromGNodeId}"
+                " must have format UuidCanonicalTextual"
             )
-        if not isinstance(self.AboutGNodeAlias, str):
+        if not isinstance(self.StatusUid, str):
             errors.append(
-                f"AboutGNodeAlias {self.AboutGNodeAlias} must have type str."
+                f"StatusUid {self.StatusUid} must have type str."
             )
-        if not property_format.is_lrd_alias_format(self.AboutGNodeAlias):
+        if not property_format.is_uuid_canonical_textual(self.StatusUid):
             errors.append(
-                f"AboutGNodeAlias {self.AboutGNodeAlias}"
-                " must have format LrdAliasFormat"
+                f"StatusUid {self.StatusUid}"
+                " must have format UuidCanonicalTextual"
             )
         if not isinstance(self.ReportingPeriodS, int):
             errors.append(
                 f"ReportingPeriodS {self.ReportingPeriodS} must have type int."
             )
-        if self.TypeAlias != "gt.sh.status.100":
+        if self.TypeAlias != "gt.sh.status.110":
             errors.append(
-                f"Type requires TypeAlias of gt.sh.status.100, not {self.TypeAlias}."
+                f"Type requires TypeAlias of gt.sh.status.110, not {self.TypeAlias}."
             )
 
         return errors

--- a/gw_spaceheat/schema/gt/gt_sh_status/gt_sh_status_maker.py
+++ b/gw_spaceheat/schema/gt/gt_sh_status/gt_sh_status_maker.py
@@ -1,16 +1,16 @@
-"""Makes gt.sh.status.100 type"""
+"""Makes gt.sh.status.110 type"""
 import json
 from typing import List
 
 from schema.gt.gt_sh_status.gt_sh_status import GtShStatus
 from schema.errors import MpSchemaError
-from schema.gt.gt_sh_booleanactuator_cmd_status.gt_sh_booleanactuator_cmd_status_maker import (
-    GtShBooleanactuatorCmdStatus,
-    GtShBooleanactuatorCmdStatus_Maker,
-)
 from schema.gt.gt_sh_simple_telemetry_status.gt_sh_simple_telemetry_status_maker import (
     GtShSimpleTelemetryStatus,
     GtShSimpleTelemetryStatus_Maker,
+)
+from schema.gt.gt_sh_booleanactuator_cmd_status.gt_sh_booleanactuator_cmd_status_maker import (
+    GtShBooleanactuatorCmdStatus,
+    GtShBooleanactuatorCmdStatus_Maker,
 )
 from schema.gt.gt_sh_multipurpose_telemetry_status.gt_sh_multipurpose_telemetry_status_maker import (
     GtShMultipurposeTelemetryStatus,
@@ -19,22 +19,28 @@ from schema.gt.gt_sh_multipurpose_telemetry_status.gt_sh_multipurpose_telemetry_
 
 
 class GtShStatus_Maker:
-    type_alias = "gt.sh.status.100"
+    type_alias = "gt.sh.status.110"
 
     def __init__(self,
-                 booleanactuator_cmd_list: List[GtShBooleanactuatorCmdStatus],
-                 simple_telemetry_list: List[GtShSimpleTelemetryStatus],
-                 multipurpose_telemetry_list: List[GtShMultipurposeTelemetryStatus],
                  slot_start_unix_s: int,
+                 simple_telemetry_list: List[GtShSimpleTelemetryStatus],
                  about_g_node_alias: str,
+                 booleanactuator_cmd_list: List[GtShBooleanactuatorCmdStatus],
+                 from_g_node_alias: str,
+                 multipurpose_telemetry_list: List[GtShMultipurposeTelemetryStatus],
+                 from_g_node_id: str,
+                 status_uid: str,
                  reporting_period_s: int):
 
         gw_tuple = GtShStatus(
-            BooleanactuatorCmdList=booleanactuator_cmd_list,
-            SimpleTelemetryList=simple_telemetry_list,
-            MultipurposeTelemetryList=multipurpose_telemetry_list,
             SlotStartUnixS=slot_start_unix_s,
+            SimpleTelemetryList=simple_telemetry_list,
             AboutGNodeAlias=about_g_node_alias,
+            BooleanactuatorCmdList=booleanactuator_cmd_list,
+            FromGNodeAlias=from_g_node_alias,
+            MultipurposeTelemetryList=multipurpose_telemetry_list,
+            FromGNodeId=from_g_node_id,
+            StatusUid=status_uid,
             ReportingPeriodS=reporting_period_s,
             #
         )
@@ -63,19 +69,8 @@ class GtShStatus_Maker:
             new_d[key] = d[key]
         if "TypeAlias" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing TypeAlias")
-        if "BooleanactuatorCmdList" not in new_d.keys():
-            raise MpSchemaError(f"dict {new_d} missing BooleanactuatorCmdList")
-        booleanactuator_cmd_list = []
-        for elt in new_d["BooleanactuatorCmdList"]:
-            if not isinstance(elt, dict):
-                raise MpSchemaError(
-                    f"elt {elt} of BooleanactuatorCmdList must be "
-                    "GtShBooleanactuatorCmdStatus but not even a dict!"
-                )
-            booleanactuator_cmd_list.append(
-                GtShBooleanactuatorCmdStatus_Maker.dict_to_tuple(elt)
-            )
-        new_d["BooleanactuatorCmdList"] = booleanactuator_cmd_list
+        if "SlotStartUnixS" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing SlotStartUnixS")
         if "SimpleTelemetryList" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing SimpleTelemetryList")
         simple_telemetry_list = []
@@ -89,6 +84,23 @@ class GtShStatus_Maker:
                 GtShSimpleTelemetryStatus_Maker.dict_to_tuple(elt)
             )
         new_d["SimpleTelemetryList"] = simple_telemetry_list
+        if "AboutGNodeAlias" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing AboutGNodeAlias")
+        if "BooleanactuatorCmdList" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing BooleanactuatorCmdList")
+        booleanactuator_cmd_list = []
+        for elt in new_d["BooleanactuatorCmdList"]:
+            if not isinstance(elt, dict):
+                raise MpSchemaError(
+                    f"elt {elt} of BooleanactuatorCmdList must be "
+                    "GtShBooleanactuatorCmdStatus but not even a dict!"
+                )
+            booleanactuator_cmd_list.append(
+                GtShBooleanactuatorCmdStatus_Maker.dict_to_tuple(elt)
+            )
+        new_d["BooleanactuatorCmdList"] = booleanactuator_cmd_list
+        if "FromGNodeAlias" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing FromGNodeAlias")
         if "MultipurposeTelemetryList" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing MultipurposeTelemetryList")
         multipurpose_telemetry_list = []
@@ -102,20 +114,23 @@ class GtShStatus_Maker:
                 GtShMultipurposeTelemetryStatus_Maker.dict_to_tuple(elt)
             )
         new_d["MultipurposeTelemetryList"] = multipurpose_telemetry_list
-        if "SlotStartUnixS" not in new_d.keys():
-            raise MpSchemaError(f"dict {new_d} missing SlotStartUnixS")
-        if "AboutGNodeAlias" not in new_d.keys():
-            raise MpSchemaError(f"dict {new_d} missing AboutGNodeAlias")
+        if "FromGNodeId" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing FromGNodeId")
+        if "StatusUid" not in new_d.keys():
+            raise MpSchemaError(f"dict {new_d} missing StatusUid")
         if "ReportingPeriodS" not in new_d.keys():
             raise MpSchemaError(f"dict {new_d} missing ReportingPeriodS")
 
         gw_tuple = GtShStatus(
             TypeAlias=new_d["TypeAlias"],
-            BooleanactuatorCmdList=new_d["BooleanactuatorCmdList"],
-            SimpleTelemetryList=new_d["SimpleTelemetryList"],
-            MultipurposeTelemetryList=new_d["MultipurposeTelemetryList"],
             SlotStartUnixS=new_d["SlotStartUnixS"],
+            SimpleTelemetryList=new_d["SimpleTelemetryList"],
             AboutGNodeAlias=new_d["AboutGNodeAlias"],
+            BooleanactuatorCmdList=new_d["BooleanactuatorCmdList"],
+            FromGNodeAlias=new_d["FromGNodeAlias"],
+            MultipurposeTelemetryList=new_d["MultipurposeTelemetryList"],
+            FromGNodeId=new_d["FromGNodeId"],
+            StatusUid=new_d["StatusUid"],
             ReportingPeriodS=new_d["ReportingPeriodS"],
             #
         )

--- a/gw_spaceheat/schema/schema_switcher.py
+++ b/gw_spaceheat/schema/schema_switcher.py
@@ -2,7 +2,10 @@ from typing import Dict, List
 
 from schema.gs.gs_dispatch_maker import GsDispatch_Maker
 from schema.gs.gs_pwr_maker import GsPwr_Maker
-from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch_Maker
+from schema.gt.gt_dispatch_boolean.gt_dispatch_boolean_maker \
+    import GtDispatchBoolean_Maker
+from schema. gt.gt_dispatch_boolean_local.gt_dispatch_boolean_local_maker \
+    import GtDispatchBooleanLocal_Maker
 from schema.gt.gt_driver_booleanactuator_cmd.gt_driver_booleanactuator_cmd_maker \
     import GtDriverBooleanactuatorCmd_Maker
 from schema.gt.gt_sh_cli_atn_cmd.gt_sh_cli_atn_cmd_maker import GtShCliAtnCmd_Maker
@@ -23,7 +26,8 @@ TypeMakerByAliasDict: Dict[str, GtTelemetry_Maker] = {}
 schema_makers: List[GtTelemetry_Maker] = [
     GsDispatch_Maker,
     GsPwr_Maker,
-    GtDispatch_Maker,
+    GtDispatchBoolean_Maker,
+    GtDispatchBooleanLocal_Maker,
     GtDriverBooleanactuatorCmd_Maker,
     GtShCliAtnCmd_Maker,
     GtShCliScadaResponse_Maker,

--- a/gw_spaceheat/template_settings.py
+++ b/gw_spaceheat/template_settings.py
@@ -5,7 +5,7 @@ LOCAL_MQTT_USER_NAME = None
 GW_MQTT_BROKER_ADDRESS = "mqtt.eclipseprojects.io"
 GW_MQTT_USER_NAME = None
 
-ATN_G_NODE_ALIAS = "dwtest.isone.nh.orange.1"
+WORLD_ROOT_ALIAS = "dwtest"
 
 LOCAL_MQTT_MESSAGE_DELTA_S = 0.05
 GW_MQTT_MESSAGE_DELTA = 0.05

--- a/test/schema/test_gt_dispatch_boolean.py
+++ b/test/schema/test_gt_dispatch_boolean.py
@@ -1,0 +1,178 @@
+"""Tests gt.dispatch.boolean.100 type"""
+import json
+
+import pytest
+
+from schema.errors import MpSchemaError
+from schema.gt.gt_dispatch_boolean.gt_dispatch_boolean_maker import (
+    GtDispatchBoolean_Maker as Maker,
+)
+
+
+def test_gt_dispatch_boolean():
+
+    gw_dict = {
+        "AboutNodeAlias": "a.elt1.relay",
+        "ToGNodeAlias": "dwtest.isone.ct.newhaven.orange1.ta.scada",
+        "FromGNodeAlias": "dwtest.isone.ct.newhaven.orange1",
+        "FromGNodeId": "e7f7d6cc-08b0-4b36-bbbb-0a1f8447fd32",
+        "RelayState": 0,
+        "SendTimeUnixMs": 1657024737661,
+        "TypeAlias": "gt.dispatch.boolean.100",
+    }
+
+    with pytest.raises(MpSchemaError):
+        Maker.type_to_tuple(gw_dict)
+
+    with pytest.raises(MpSchemaError):
+        Maker.type_to_tuple('"not a dict"')
+
+    # Test type_to_tuple
+    gw_type = json.dumps(gw_dict)
+    gw_tuple = Maker.type_to_tuple(gw_type)
+
+    # test type_to_tuple and tuple_to_type maps
+    assert Maker.type_to_tuple(Maker.tuple_to_type(gw_tuple)) == gw_tuple
+
+    # test Maker init
+    t = Maker(
+        about_node_alias=gw_tuple.AboutNodeAlias,
+        to_g_node_alias=gw_tuple.ToGNodeAlias,
+        from_g_node_alias=gw_tuple.FromGNodeAlias,
+        from_g_node_id=gw_tuple.FromGNodeId,
+        relay_state=gw_tuple.RelayState,
+        send_time_unix_ms=gw_tuple.SendTimeUnixMs,
+        #
+    ).tuple
+    assert t == gw_tuple
+
+    ######################################
+    # MpSchemaError raised if missing a required attribute
+    ######################################
+
+    orig_value = gw_dict["TypeAlias"]
+    del gw_dict["TypeAlias"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["TypeAlias"] = orig_value
+
+    orig_value = gw_dict["AboutNodeAlias"]
+    del gw_dict["AboutNodeAlias"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["AboutNodeAlias"] = orig_value
+
+    orig_value = gw_dict["ToGNodeAlias"]
+    del gw_dict["ToGNodeAlias"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["ToGNodeAlias"] = orig_value
+
+    orig_value = gw_dict["FromGNodeAlias"]
+    del gw_dict["FromGNodeAlias"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = orig_value
+
+    orig_value = gw_dict["FromGNodeId"]
+    del gw_dict["FromGNodeId"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeId"] = orig_value
+
+    orig_value = gw_dict["RelayState"]
+    del gw_dict["RelayState"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["RelayState"] = orig_value
+
+    orig_value = gw_dict["SendTimeUnixMs"]
+    del gw_dict["SendTimeUnixMs"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["SendTimeUnixMs"] = orig_value
+
+    ######################################
+    # MpSchemaError raised if attributes have incorrect type
+    ######################################
+
+    orig_value = gw_dict["AboutNodeAlias"]
+    gw_dict["AboutNodeAlias"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["AboutNodeAlias"] = orig_value
+
+    orig_value = gw_dict["ToGNodeAlias"]
+    gw_dict["ToGNodeAlias"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["ToGNodeAlias"] = orig_value
+
+    orig_value = gw_dict["FromGNodeAlias"]
+    gw_dict["FromGNodeAlias"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = orig_value
+
+    orig_value = gw_dict["FromGNodeId"]
+    gw_dict["FromGNodeId"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeId"] = orig_value
+
+    orig_value = gw_dict["RelayState"]
+    gw_dict["RelayState"] = 1.1
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["RelayState"] = orig_value
+
+    orig_value = gw_dict["SendTimeUnixMs"]
+    gw_dict["SendTimeUnixMs"] = 1.1
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["SendTimeUnixMs"] = orig_value
+
+    ######################################
+    # MpSchemaError raised if TypeAlias is incorrect
+    ######################################
+
+    gw_dict["TypeAlias"] = "not the type alias"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["TypeAlias"] = "gt.dispatch.boolean.100"
+
+    ######################################
+    # MpSchemaError raised if primitive attributes do not have appropriate property_format
+    ######################################
+
+    gw_dict["AboutNodeAlias"] = "a.b-h"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["AboutNodeAlias"] = "a.elt1.relay"
+
+    gw_dict["ToGNodeAlias"] = "a.b-h"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["ToGNodeAlias"] = "dwtest.isone.ct.newhaven.orange1.ta.scada"
+
+    gw_dict["FromGNodeAlias"] = "a.b-h"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = "dwtest.isone.ct.newhaven.orange1"
+
+    gw_dict["FromGNodeId"] = "d4be12d5-33ba-4f1f-b9e5"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeId"] = "e7f7d6cc-08b0-4b36-bbbb-0a1f8447fd32"
+
+    gw_dict["RelayState"] = 2
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["RelayState"] = 0
+
+    gw_dict["SendTimeUnixMs"] = 1656245000
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["SendTimeUnixMs"] = 1657024737661
+
+    # End of Test

--- a/test/schema/test_gt_dispatch_boolean_local.py
+++ b/test/schema/test_gt_dispatch_boolean_local.py
@@ -1,21 +1,22 @@
-"""Tests gt.dispatch.110 type"""
+"""Tests gt.dispatch.boolean.local.100 type"""
 import json
 
 import pytest
 
 from schema.errors import MpSchemaError
-from schema.gt.gt_dispatch.gt_dispatch_maker import (
-    GtDispatch_Maker as Maker,
+from schema.gt.gt_dispatch_boolean_local.gt_dispatch_boolean_local_maker import (
+    GtDispatchBooleanLocal_Maker as Maker,
 )
 
 
-def test_gt_dispatch():
+def test_gt_dispatch_boolean_local():
 
     gw_dict = {
-        "ShNodeAlias": "a.elt1.relay",
-        "SendTimeUnixMs": 1656869326597,
-        "RelayState": 0,
-        "TypeAlias": "gt.dispatch.110",
+        "SendTimeUnixMs": 1657025211851,
+        "FromNodeAlias": "a.s",
+        "AboutNodeAlias": "a.elt1.relay",
+        "RelayState": 1,
+        "TypeAlias": "gt.dispatch.boolean.local.100",
     }
 
     with pytest.raises(MpSchemaError):
@@ -33,8 +34,9 @@ def test_gt_dispatch():
 
     # test Maker init
     t = Maker(
-        sh_node_alias=gw_tuple.ShNodeAlias,
         send_time_unix_ms=gw_tuple.SendTimeUnixMs,
+        from_node_alias=gw_tuple.FromNodeAlias,
+        about_node_alias=gw_tuple.AboutNodeAlias,
         relay_state=gw_tuple.RelayState,
         #
     ).tuple
@@ -50,17 +52,23 @@ def test_gt_dispatch():
         Maker.dict_to_tuple(gw_dict)
     gw_dict["TypeAlias"] = orig_value
 
-    orig_value = gw_dict["ShNodeAlias"]
-    del gw_dict["ShNodeAlias"]
-    with pytest.raises(MpSchemaError):
-        Maker.dict_to_tuple(gw_dict)
-    gw_dict["ShNodeAlias"] = orig_value
-
     orig_value = gw_dict["SendTimeUnixMs"]
     del gw_dict["SendTimeUnixMs"]
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
     gw_dict["SendTimeUnixMs"] = orig_value
+
+    orig_value = gw_dict["FromNodeAlias"]
+    del gw_dict["FromNodeAlias"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromNodeAlias"] = orig_value
+
+    orig_value = gw_dict["AboutNodeAlias"]
+    del gw_dict["AboutNodeAlias"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["AboutNodeAlias"] = orig_value
 
     orig_value = gw_dict["RelayState"]
     del gw_dict["RelayState"]
@@ -72,17 +80,23 @@ def test_gt_dispatch():
     # MpSchemaError raised if attributes have incorrect type
     ######################################
 
-    orig_value = gw_dict["ShNodeAlias"]
-    gw_dict["ShNodeAlias"] = 42
-    with pytest.raises(MpSchemaError):
-        Maker.dict_to_tuple(gw_dict)
-    gw_dict["ShNodeAlias"] = orig_value
-
     orig_value = gw_dict["SendTimeUnixMs"]
     gw_dict["SendTimeUnixMs"] = 1.1
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
     gw_dict["SendTimeUnixMs"] = orig_value
+
+    orig_value = gw_dict["FromNodeAlias"]
+    gw_dict["FromNodeAlias"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromNodeAlias"] = orig_value
+
+    orig_value = gw_dict["AboutNodeAlias"]
+    gw_dict["AboutNodeAlias"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["AboutNodeAlias"] = orig_value
 
     orig_value = gw_dict["RelayState"]
     gw_dict["RelayState"] = 1.1
@@ -97,25 +111,30 @@ def test_gt_dispatch():
     gw_dict["TypeAlias"] = "not the type alias"
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["TypeAlias"] = "gt.dispatch.110"
+    gw_dict["TypeAlias"] = "gt.dispatch.boolean.local.100"
 
     ######################################
     # MpSchemaError raised if primitive attributes do not have appropriate property_format
     ######################################
 
-    gw_dict["ShNodeAlias"] = "a.b-h"
-    with pytest.raises(MpSchemaError):
-        Maker.dict_to_tuple(gw_dict)
-    gw_dict["ShNodeAlias"] = "a.elt1.relay"
-
     gw_dict["SendTimeUnixMs"] = 1656245000
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["SendTimeUnixMs"] = 1656869326597
+    gw_dict["SendTimeUnixMs"] = 1657025211851
+
+    gw_dict["FromNodeAlias"] = "a.b-h"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromNodeAlias"] = "a.s"
+
+    gw_dict["AboutNodeAlias"] = "a.b-h"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["AboutNodeAlias"] = "a.elt1.relay"
 
     gw_dict["RelayState"] = 2
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["RelayState"] = 0
+    gw_dict["RelayState"] = 1
 
     # End of Test

--- a/test/schema/test_gt_sh_cli_atn_cmd.py
+++ b/test/schema/test_gt_sh_cli_atn_cmd.py
@@ -1,4 +1,4 @@
-"""Tests gt.sh.cli.atn.cmd.100 type"""
+"""Tests gt.sh.cli.atn.cmd.110 type"""
 import json
 
 import pytest
@@ -12,8 +12,10 @@ from schema.gt.gt_sh_cli_atn_cmd.gt_sh_cli_atn_cmd_maker import (
 def test_gt_sh_cli_atn_cmd():
 
     gw_dict = {
+        "FromGNodeAlias": "dwtest.isone.ct.newhaven.orange1",
         "SendSnapshot": True,
-        "TypeAlias": "gt.sh.cli.atn.cmd.100",
+        "FromGNodeId": "e7f7d6cc-08b0-4b36-bbbb-0a1f8447fd32",
+        "TypeAlias": "gt.sh.cli.atn.cmd.110",
     }
 
     with pytest.raises(MpSchemaError):
@@ -31,7 +33,9 @@ def test_gt_sh_cli_atn_cmd():
 
     # test Maker init
     t = Maker(
+        from_g_node_alias=gw_tuple.FromGNodeAlias,
         send_snapshot=gw_tuple.SendSnapshot,
+        from_g_node_id=gw_tuple.FromGNodeId,
         #
     ).tuple
     assert t == gw_tuple
@@ -46,21 +50,45 @@ def test_gt_sh_cli_atn_cmd():
         Maker.dict_to_tuple(gw_dict)
     gw_dict["TypeAlias"] = orig_value
 
+    orig_value = gw_dict["FromGNodeAlias"]
+    del gw_dict["FromGNodeAlias"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = orig_value
+
     orig_value = gw_dict["SendSnapshot"]
     del gw_dict["SendSnapshot"]
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
     gw_dict["SendSnapshot"] = orig_value
 
+    orig_value = gw_dict["FromGNodeId"]
+    del gw_dict["FromGNodeId"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeId"] = orig_value
+
     ######################################
     # MpSchemaError raised if attributes have incorrect type
     ######################################
+
+    orig_value = gw_dict["FromGNodeAlias"]
+    gw_dict["FromGNodeAlias"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = orig_value
 
     orig_value = gw_dict["SendSnapshot"]
     gw_dict["SendSnapshot"] = "This string is not a boolean."
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
     gw_dict["SendSnapshot"] = orig_value
+
+    orig_value = gw_dict["FromGNodeId"]
+    gw_dict["FromGNodeId"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeId"] = orig_value
 
     ######################################
     # MpSchemaError raised if TypeAlias is incorrect
@@ -69,4 +97,20 @@ def test_gt_sh_cli_atn_cmd():
     gw_dict["TypeAlias"] = "not the type alias"
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["TypeAlias"] = "gt.sh.cli.atn.cmd.100"
+    gw_dict["TypeAlias"] = "gt.sh.cli.atn.cmd.110"
+
+    ######################################
+    # MpSchemaError raised if primitive attributes do not have appropriate property_format
+    ######################################
+
+    gw_dict["FromGNodeAlias"] = "a.b-h"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = "dwtest.isone.ct.newhaven.orange1"
+
+    gw_dict["FromGNodeId"] = "d4be12d5-33ba-4f1f-b9e5"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeId"] = "e7f7d6cc-08b0-4b36-bbbb-0a1f8447fd32"
+
+    # End of Test

--- a/test/schema/test_gt_sh_cli_scada_response.py
+++ b/test/schema/test_gt_sh_cli_scada_response.py
@@ -1,4 +1,4 @@
-"""Tests gt.sh.cli.scada.response.100 type"""
+"""Tests gt.sh.cli.scada.response.110 type"""
 import json
 
 import pytest
@@ -12,6 +12,8 @@ from schema.gt.gt_sh_cli_scada_response.gt_sh_cli_scada_response_maker import (
 def test_gt_sh_cli_scada_response():
 
     gw_dict = {
+        "FromGNodeAlias": "dwtest.isone.ct.newhaven.orange1.ta.scada",
+        "FromGNodeId": "0384ef21-648b-4455-b917-58a1172d7fc1",
         "Snapshot": {
             "TelemetryNameList": ["5a71d4b3"],
             "AboutNodeAliasList": ["a.elt1.relay"],
@@ -19,7 +21,7 @@ def test_gt_sh_cli_scada_response():
             "ValueList": [1],
             "TypeAlias": "gt.sh.status.snapshot.110",
         },
-        "TypeAlias": "gt.sh.cli.scada.response.100",
+        "TypeAlias": "gt.sh.cli.scada.response.110",
     }
 
     with pytest.raises(MpSchemaError):
@@ -37,6 +39,8 @@ def test_gt_sh_cli_scada_response():
 
     # test Maker init
     t = Maker(
+        from_g_node_alias=gw_tuple.FromGNodeAlias,
+        from_g_node_id=gw_tuple.FromGNodeId,
         snapshot=gw_tuple.Snapshot,
         #
     ).tuple
@@ -52,6 +56,18 @@ def test_gt_sh_cli_scada_response():
         Maker.dict_to_tuple(gw_dict)
     gw_dict["TypeAlias"] = orig_value
 
+    orig_value = gw_dict["FromGNodeAlias"]
+    del gw_dict["FromGNodeAlias"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = orig_value
+
+    orig_value = gw_dict["FromGNodeId"]
+    del gw_dict["FromGNodeId"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeId"] = orig_value
+
     orig_value = gw_dict["Snapshot"]
     del gw_dict["Snapshot"]
     with pytest.raises(MpSchemaError):
@@ -62,6 +78,18 @@ def test_gt_sh_cli_scada_response():
     # MpSchemaError raised if attributes have incorrect type
     ######################################
 
+    orig_value = gw_dict["FromGNodeAlias"]
+    gw_dict["FromGNodeAlias"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = orig_value
+
+    orig_value = gw_dict["FromGNodeId"]
+    gw_dict["FromGNodeId"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeId"] = orig_value
+
     orig_value = gw_dict["Snapshot"]
     gw_dict["Snapshot"] = "Not a GtShStatusSnapshot."
     with pytest.raises(MpSchemaError):
@@ -70,6 +98,8 @@ def test_gt_sh_cli_scada_response():
 
     with pytest.raises(MpSchemaError):
         Maker(
+            from_g_node_alias=gw_tuple.FromGNodeAlias,
+            from_g_node_id=gw_tuple.FromGNodeId,
             snapshot="Not a GtShStatusSnapshot",
         )
 
@@ -80,4 +110,20 @@ def test_gt_sh_cli_scada_response():
     gw_dict["TypeAlias"] = "not the type alias"
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["TypeAlias"] = "gt.sh.cli.scada.response.100"
+    gw_dict["TypeAlias"] = "gt.sh.cli.scada.response.110"
+
+    ######################################
+    # MpSchemaError raised if primitive attributes do not have appropriate property_format
+    ######################################
+
+    gw_dict["FromGNodeAlias"] = "a.b-h"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = "dwtest.isone.ct.newhaven.orange1.ta.scada"
+
+    gw_dict["FromGNodeId"] = "d4be12d5-33ba-4f1f-b9e5"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeId"] = "0384ef21-648b-4455-b917-58a1172d7fc1"
+
+    # End of Test

--- a/test/schema/test_gt_sh_status.py
+++ b/test/schema/test_gt_sh_status.py
@@ -1,4 +1,4 @@
-"""Tests gt.sh.status.100 type"""
+"""Tests gt.sh.status.110 type"""
 import json
 
 import pytest
@@ -12,14 +12,7 @@ from schema.gt.gt_sh_status.gt_sh_status_maker import (
 def test_gt_sh_status():
 
     gw_dict = {
-        "BooleanactuatorCmdList": [
-            {
-                "ShNodeAlias": "a.elt1.relay",
-                "RelayStateCommandList": [1],
-                "CommandTimeUnixMsList": [1656945413464],
-                "TypeAlias": "gt.sh.booleanactuator.cmd.status.100",
-            }
-        ],
+        "SlotStartUnixS": 1656945300,
         "SimpleTelemetryList": [
             {
                 "ValueList": [0, 1],
@@ -29,6 +22,16 @@ def test_gt_sh_status():
                 "TelemetryNameGtEnumSymbol": "5a71d4b3",
             }
         ],
+        "AboutGNodeAlias": "dwtest.isone.ct.newhaven.orange1.ta",
+        "BooleanactuatorCmdList": [
+            {
+                "ShNodeAlias": "a.elt1.relay",
+                "RelayStateCommandList": [1],
+                "CommandTimeUnixMsList": [1656945413464],
+                "TypeAlias": "gt.sh.booleanactuator.cmd.status.100",
+            }
+        ],
+        "FromGNodeAlias": "dwtest.isone.ct.newhaven.orange1.ta.scada",
         "MultipurposeTelemetryList": [
             {
                 "AboutNodeAlias": "a.elt1",
@@ -39,10 +42,10 @@ def test_gt_sh_status():
                 "TelemetryNameGtEnumSymbol": "ad19e79c",
             }
         ],
-        "SlotStartUnixS": 1656945300,
-        "AboutGNodeAlias": "dwjess.isone.nh.orange.1.ta",
+        "FromGNodeId": "0384ef21-648b-4455-b917-58a1172d7fc1",
+        "StatusUid": "dedc25c2-8276-4b25-abd6-f53edc79b62b",
         "ReportingPeriodS": 300,
-        "TypeAlias": "gt.sh.status.100",
+        "TypeAlias": "gt.sh.status.110",
     }
 
     with pytest.raises(MpSchemaError):
@@ -60,11 +63,14 @@ def test_gt_sh_status():
 
     # test Maker init
     t = Maker(
-        booleanactuator_cmd_list=gw_tuple.BooleanactuatorCmdList,
-        simple_telemetry_list=gw_tuple.SimpleTelemetryList,
-        multipurpose_telemetry_list=gw_tuple.MultipurposeTelemetryList,
         slot_start_unix_s=gw_tuple.SlotStartUnixS,
+        simple_telemetry_list=gw_tuple.SimpleTelemetryList,
         about_g_node_alias=gw_tuple.AboutGNodeAlias,
+        booleanactuator_cmd_list=gw_tuple.BooleanactuatorCmdList,
+        from_g_node_alias=gw_tuple.FromGNodeAlias,
+        multipurpose_telemetry_list=gw_tuple.MultipurposeTelemetryList,
+        from_g_node_id=gw_tuple.FromGNodeId,
+        status_uid=gw_tuple.StatusUid,
         reporting_period_s=gw_tuple.ReportingPeriodS,
         #
     ).tuple
@@ -80,11 +86,11 @@ def test_gt_sh_status():
         Maker.dict_to_tuple(gw_dict)
     gw_dict["TypeAlias"] = orig_value
 
-    orig_value = gw_dict["BooleanactuatorCmdList"]
-    del gw_dict["BooleanactuatorCmdList"]
+    orig_value = gw_dict["SlotStartUnixS"]
+    del gw_dict["SlotStartUnixS"]
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["BooleanactuatorCmdList"] = orig_value
+    gw_dict["SlotStartUnixS"] = orig_value
 
     orig_value = gw_dict["SimpleTelemetryList"]
     del gw_dict["SimpleTelemetryList"]
@@ -92,23 +98,41 @@ def test_gt_sh_status():
         Maker.dict_to_tuple(gw_dict)
     gw_dict["SimpleTelemetryList"] = orig_value
 
+    orig_value = gw_dict["AboutGNodeAlias"]
+    del gw_dict["AboutGNodeAlias"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["AboutGNodeAlias"] = orig_value
+
+    orig_value = gw_dict["BooleanactuatorCmdList"]
+    del gw_dict["BooleanactuatorCmdList"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["BooleanactuatorCmdList"] = orig_value
+
+    orig_value = gw_dict["FromGNodeAlias"]
+    del gw_dict["FromGNodeAlias"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = orig_value
+
     orig_value = gw_dict["MultipurposeTelemetryList"]
     del gw_dict["MultipurposeTelemetryList"]
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
     gw_dict["MultipurposeTelemetryList"] = orig_value
 
-    orig_value = gw_dict["SlotStartUnixS"]
-    del gw_dict["SlotStartUnixS"]
+    orig_value = gw_dict["FromGNodeId"]
+    del gw_dict["FromGNodeId"]
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["SlotStartUnixS"] = orig_value
+    gw_dict["FromGNodeId"] = orig_value
 
-    orig_value = gw_dict["AboutGNodeAlias"]
-    del gw_dict["AboutGNodeAlias"]
+    orig_value = gw_dict["StatusUid"]
+    del gw_dict["StatusUid"]
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["AboutGNodeAlias"] = orig_value
+    gw_dict["StatusUid"] = orig_value
 
     orig_value = gw_dict["ReportingPeriodS"]
     del gw_dict["ReportingPeriodS"]
@@ -120,41 +144,11 @@ def test_gt_sh_status():
     # MpSchemaError raised if attributes have incorrect type
     ######################################
 
-    orig_value = gw_dict["BooleanactuatorCmdList"]
-    gw_dict["BooleanactuatorCmdList"] = "Not a list."
+    orig_value = gw_dict["SlotStartUnixS"]
+    gw_dict["SlotStartUnixS"] = 1.1
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["BooleanactuatorCmdList"] = orig_value
-
-    orig_value = gw_dict["BooleanactuatorCmdList"]
-    gw_dict["BooleanactuatorCmdList"] = ["Not even a dict"]
-    with pytest.raises(MpSchemaError):
-        Maker.dict_to_tuple(gw_dict)
-
-    gw_dict["BooleanactuatorCmdList"] = [{"Failed": "Not a GtSimpleSingleStatus"}]
-    with pytest.raises(MpSchemaError):
-        Maker.dict_to_tuple(gw_dict)
-    gw_dict["BooleanactuatorCmdList"] = orig_value
-
-    with pytest.raises(MpSchemaError):
-        Maker(
-            simple_telemetry_list=gw_dict["SimpleTelemetryList"],
-            multipurpose_telemetry_list=gw_dict["MultipurposeTelemetryList"],
-            slot_start_unix_s=gw_dict["SlotStartUnixS"],
-            about_g_node_alias=gw_dict["AboutGNodeAlias"],
-            reporting_period_s=gw_dict["ReportingPeriodS"],
-            booleanactuator_cmd_list=["Not a GtShBooleanactuatorCmdStatus"],
-        )
-
-    with pytest.raises(MpSchemaError):
-        Maker(
-            simple_telemetry_list=gw_tuple.SimpleTelemetryList,
-            multipurpose_telemetry_list=gw_tuple.MultipurposeTelemetryList,
-            slot_start_unix_s=gw_tuple.SlotStartUnixS,
-            about_g_node_alias=gw_tuple.AboutGNodeAlias,
-            reporting_period_s=gw_tuple.ReportingPeriodS,
-            booleanactuator_cmd_list="This string is not a list",
-        )
+    gw_dict["SlotStartUnixS"] = orig_value
 
     orig_value = gw_dict["SimpleTelemetryList"]
     gw_dict["SimpleTelemetryList"] = "Not a list."
@@ -174,23 +168,83 @@ def test_gt_sh_status():
 
     with pytest.raises(MpSchemaError):
         Maker(
-            booleanactuator_cmd_list=gw_dict["BooleanactuatorCmdList"],
-            multipurpose_telemetry_list=gw_dict["MultipurposeTelemetryList"],
             slot_start_unix_s=gw_dict["SlotStartUnixS"],
             about_g_node_alias=gw_dict["AboutGNodeAlias"],
+            booleanactuator_cmd_list=gw_dict["BooleanactuatorCmdList"],
+            from_g_node_alias=gw_dict["FromGNodeAlias"],
+            multipurpose_telemetry_list=gw_dict["MultipurposeTelemetryList"],
+            from_g_node_id=gw_dict["FromGNodeId"],
+            status_uid=gw_dict["StatusUid"],
             reporting_period_s=gw_dict["ReportingPeriodS"],
             simple_telemetry_list=["Not a GtShSimpleTelemetryStatus"],
         )
 
     with pytest.raises(MpSchemaError):
         Maker(
-            booleanactuator_cmd_list=gw_tuple.BooleanactuatorCmdList,
-            multipurpose_telemetry_list=gw_tuple.MultipurposeTelemetryList,
             slot_start_unix_s=gw_tuple.SlotStartUnixS,
             about_g_node_alias=gw_tuple.AboutGNodeAlias,
+            booleanactuator_cmd_list=gw_tuple.BooleanactuatorCmdList,
+            from_g_node_alias=gw_tuple.FromGNodeAlias,
+            multipurpose_telemetry_list=gw_tuple.MultipurposeTelemetryList,
+            from_g_node_id=gw_tuple.FromGNodeId,
+            status_uid=gw_tuple.StatusUid,
             reporting_period_s=gw_tuple.ReportingPeriodS,
             simple_telemetry_list="This string is not a list",
         )
+
+    orig_value = gw_dict["AboutGNodeAlias"]
+    gw_dict["AboutGNodeAlias"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["AboutGNodeAlias"] = orig_value
+
+    orig_value = gw_dict["BooleanactuatorCmdList"]
+    gw_dict["BooleanactuatorCmdList"] = "Not a list."
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["BooleanactuatorCmdList"] = orig_value
+
+    orig_value = gw_dict["BooleanactuatorCmdList"]
+    gw_dict["BooleanactuatorCmdList"] = ["Not even a dict"]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+
+    gw_dict["BooleanactuatorCmdList"] = [{"Failed": "Not a GtSimpleSingleStatus"}]
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["BooleanactuatorCmdList"] = orig_value
+
+    with pytest.raises(MpSchemaError):
+        Maker(
+            slot_start_unix_s=gw_dict["SlotStartUnixS"],
+            simple_telemetry_list=gw_dict["SimpleTelemetryList"],
+            about_g_node_alias=gw_dict["AboutGNodeAlias"],
+            from_g_node_alias=gw_dict["FromGNodeAlias"],
+            multipurpose_telemetry_list=gw_dict["MultipurposeTelemetryList"],
+            from_g_node_id=gw_dict["FromGNodeId"],
+            status_uid=gw_dict["StatusUid"],
+            reporting_period_s=gw_dict["ReportingPeriodS"],
+            booleanactuator_cmd_list=["Not a GtShBooleanactuatorCmdStatus"],
+        )
+
+    with pytest.raises(MpSchemaError):
+        Maker(
+            slot_start_unix_s=gw_tuple.SlotStartUnixS,
+            simple_telemetry_list=gw_tuple.SimpleTelemetryList,
+            about_g_node_alias=gw_tuple.AboutGNodeAlias,
+            from_g_node_alias=gw_tuple.FromGNodeAlias,
+            multipurpose_telemetry_list=gw_tuple.MultipurposeTelemetryList,
+            from_g_node_id=gw_tuple.FromGNodeId,
+            status_uid=gw_tuple.StatusUid,
+            reporting_period_s=gw_tuple.ReportingPeriodS,
+            booleanactuator_cmd_list="This string is not a list",
+        )
+
+    orig_value = gw_dict["FromGNodeAlias"]
+    gw_dict["FromGNodeAlias"] = 42
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = orig_value
 
     orig_value = gw_dict["MultipurposeTelemetryList"]
     gw_dict["MultipurposeTelemetryList"] = "Not a list."
@@ -210,35 +264,41 @@ def test_gt_sh_status():
 
     with pytest.raises(MpSchemaError):
         Maker(
-            booleanactuator_cmd_list=gw_dict["BooleanactuatorCmdList"],
-            simple_telemetry_list=gw_dict["SimpleTelemetryList"],
             slot_start_unix_s=gw_dict["SlotStartUnixS"],
+            simple_telemetry_list=gw_dict["SimpleTelemetryList"],
             about_g_node_alias=gw_dict["AboutGNodeAlias"],
+            booleanactuator_cmd_list=gw_dict["BooleanactuatorCmdList"],
+            from_g_node_alias=gw_dict["FromGNodeAlias"],
+            from_g_node_id=gw_dict["FromGNodeId"],
+            status_uid=gw_dict["StatusUid"],
             reporting_period_s=gw_dict["ReportingPeriodS"],
             multipurpose_telemetry_list=["Not a GtShMultipurposeTelemetryStatus"],
         )
 
     with pytest.raises(MpSchemaError):
         Maker(
-            booleanactuator_cmd_list=gw_tuple.BooleanactuatorCmdList,
-            simple_telemetry_list=gw_tuple.SimpleTelemetryList,
             slot_start_unix_s=gw_tuple.SlotStartUnixS,
+            simple_telemetry_list=gw_tuple.SimpleTelemetryList,
             about_g_node_alias=gw_tuple.AboutGNodeAlias,
+            booleanactuator_cmd_list=gw_tuple.BooleanactuatorCmdList,
+            from_g_node_alias=gw_tuple.FromGNodeAlias,
+            from_g_node_id=gw_tuple.FromGNodeId,
+            status_uid=gw_tuple.StatusUid,
             reporting_period_s=gw_tuple.ReportingPeriodS,
             multipurpose_telemetry_list="This string is not a list",
         )
 
-    orig_value = gw_dict["SlotStartUnixS"]
-    gw_dict["SlotStartUnixS"] = 1.1
+    orig_value = gw_dict["FromGNodeId"]
+    gw_dict["FromGNodeId"] = 42
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["SlotStartUnixS"] = orig_value
+    gw_dict["FromGNodeId"] = orig_value
 
-    orig_value = gw_dict["AboutGNodeAlias"]
-    gw_dict["AboutGNodeAlias"] = 42
+    orig_value = gw_dict["StatusUid"]
+    gw_dict["StatusUid"] = 42
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["AboutGNodeAlias"] = orig_value
+    gw_dict["StatusUid"] = orig_value
 
     orig_value = gw_dict["ReportingPeriodS"]
     gw_dict["ReportingPeriodS"] = 1.1
@@ -253,7 +313,7 @@ def test_gt_sh_status():
     gw_dict["TypeAlias"] = "not the type alias"
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["TypeAlias"] = "gt.sh.status.100"
+    gw_dict["TypeAlias"] = "gt.sh.status.110"
 
     ######################################
     # MpSchemaError raised if primitive attributes do not have appropriate property_format
@@ -267,6 +327,21 @@ def test_gt_sh_status():
     gw_dict["AboutGNodeAlias"] = "a.b-h"
     with pytest.raises(MpSchemaError):
         Maker.dict_to_tuple(gw_dict)
-    gw_dict["AboutGNodeAlias"] = "dwjess.isone.nh.orange.1.ta"
+    gw_dict["AboutGNodeAlias"] = "dwtest.isone.ct.newhaven.orange1.ta"
+
+    gw_dict["FromGNodeAlias"] = "a.b-h"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeAlias"] = "dwtest.isone.ct.newhaven.orange1.ta.scada"
+
+    gw_dict["FromGNodeId"] = "d4be12d5-33ba-4f1f-b9e5"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["FromGNodeId"] = "0384ef21-648b-4455-b917-58a1172d7fc1"
+
+    gw_dict["StatusUid"] = "d4be12d5-33ba-4f1f-b9e5"
+    with pytest.raises(MpSchemaError):
+        Maker.dict_to_tuple(gw_dict)
+    gw_dict["StatusUid"] = "dedc25c2-8276-4b25-abd6-f53edc79b62b"
 
     # End of Test

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -23,7 +23,7 @@ from schema.enums.role.role_map import Role
 from schema.enums.telemetry_name.spaceheat_telemetry_name_100 import TelemetryName
 from schema.gs.gs_dispatch import GsDispatch
 from schema.gs.gs_pwr_maker import GsPwr_Maker
-from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch_Maker
+from schema.gt.gt_dispatch_boolean.gt_dispatch_boolean_maker import GtDispatchBoolean_Maker
 from schema.gt.gt_sh_booleanactuator_cmd_status.gt_sh_booleanactuator_cmd_status_maker import (
     GtShBooleanactuatorCmdStatus,
     GtShBooleanactuatorCmdStatus_Maker,
@@ -428,7 +428,7 @@ def test_message_exchange(tmp_path, monkeypatch):
             lambda: len(ear.num_received_by_topic) > 0, 10, f"ear receipt. {ear.summary_str()}"
         )
 
-        topic = f"{scada.atn_g_node_alias}/{GtDispatch_Maker.type_alias}"
+        topic = f"{scada.atn_g_node_alias}/{GtDispatchBoolean_Maker.type_alias}"
         print(topic)
         wait_for(
             lambda: ear.num_received_by_topic[topic] > 0, 10, f"ear receipt. {ear.summary_str()}"

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -78,7 +78,7 @@ class EarRecorder(CloudEar):
         self.num_received = 0
         self.num_received_by_topic = defaultdict(int)
         self.latest_payload = None
-        super().__init__(out_stub=None, logging_on=logging_on)
+        super().__init__(logging_on=logging_on)
 
     def on_gw_mqtt_message(self, client, userdata, message):
         self.num_received += 1

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -3,14 +3,11 @@ import os
 import time
 import typing
 from collections import defaultdict
-import helpers
-import load_house
+
 import pytest
-from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch_Maker
-from schema.gt.gt_sh_booleanactuator_cmd_status.gt_sh_booleanactuator_cmd_status_maker import (
-    GtShBooleanactuatorCmdStatus_Maker,
-    GtShBooleanactuatorCmdStatus,
-)
+from utils import wait_for
+
+import load_house
 import schema.property_format
 import settings
 from actors.atn import Atn
@@ -26,21 +23,24 @@ from schema.enums.role.role_map import Role
 from schema.enums.telemetry_name.spaceheat_telemetry_name_100 import TelemetryName
 from schema.gs.gs_dispatch import GsDispatch
 from schema.gs.gs_pwr_maker import GsPwr_Maker
+from schema.gt.gt_dispatch.gt_dispatch_maker import GtDispatch_Maker
+from schema.gt.gt_sh_booleanactuator_cmd_status.gt_sh_booleanactuator_cmd_status_maker import (
+    GtShBooleanactuatorCmdStatus,
+    GtShBooleanactuatorCmdStatus_Maker,
+)
 from schema.gt.gt_sh_cli_scada_response.gt_sh_cli_scada_response_maker import GtShCliScadaResponse
+from schema.gt.gt_sh_multipurpose_telemetry_status.gt_sh_multipurpose_telemetry_status_maker import (
+    GtShMultipurposeTelemetryStatus,
+)
 from schema.gt.gt_sh_node.gt_sh_node_maker import GtShNode_Maker
 from schema.gt.gt_sh_simple_telemetry_status.gt_sh_simple_telemetry_status_maker import (
     GtShSimpleTelemetryStatus,
-)
-from schema.gt.gt_sh_multipurpose_telemetry_status.gt_sh_multipurpose_telemetry_status_maker import (
-    GtShMultipurposeTelemetryStatus,
 )
 from schema.gt.gt_sh_status.gt_sh_status_maker import GtShStatus, GtShStatus_Maker
 from schema.gt.gt_sh_telemetry_from_multipurpose_sensor.gt_sh_telemetry_from_multipurpose_sensor_maker import (
     GtShTelemetryFromMultipurposeSensor_Maker,
 )
 from schema.gt.gt_telemetry.gt_telemetry_maker import GtTelemetry_Maker
-
-from utils import wait_for
 
 LOCAL_MQTT_MESSAGE_DELTA_S = settings.LOCAL_MQTT_MESSAGE_DELTA_S
 GW_MQTT_MESSAGE_DELTA = settings.GW_MQTT_MESSAGE_DELTA
@@ -135,13 +135,13 @@ def test_imports():
 
 
 def test_load_real_house():
-    real_atn_g_node_alias = "w.isone.nh.orange.1"
+    real_world_root_alias = "w"
     current_dir = os.path.dirname(os.path.realpath(__file__))
     with open(
         os.path.join(current_dir, "../gw_spaceheat/input_data/houses.json"), "r"
     ) as read_file:
         input_data = json.load(read_file)
-    house_data = input_data[real_atn_g_node_alias]
+    house_data = input_data[real_world_root_alias]
     for d in house_data["ShNodes"]:
         GtShNode_Maker.dict_to_tuple(d)
     for node in ShNode.by_alias.values():
@@ -313,7 +313,7 @@ def test_scada_ear_connection():
         # why doesn't this work??
         # wait_for(ear.num_received > 0, 5)
         assert ear.num_received > 0
-        scada_g_node_alias = f"{settings.ATN_G_NODE_ALIAS}.ta.scada"
+        scada_g_node_alias = scada.scada_g_node_alias
         assert ear.num_received_by_topic[f"{scada_g_node_alias}/{GtShStatus_Maker.type_alias}"] == 1
         assert isinstance(ear.latest_payload, GtShStatus)
         simple_telemetry_list = ear.latest_payload.SimpleTelemetryList
@@ -428,7 +428,7 @@ def test_message_exchange(tmp_path, monkeypatch):
             lambda: len(ear.num_received_by_topic) > 0, 10, f"ear receipt. {ear.summary_str()}"
         )
 
-        topic = f"{helpers.atn_g_node_alias()}/{GtDispatch_Maker.type_alias}"
+        topic = f"{scada.atn_g_node_alias}/{GtDispatch_Maker.type_alias}"
         print(topic)
         wait_for(
             lambda: ear.num_received_by_topic[topic] > 0, 10, f"ear receipt. {ear.summary_str()}"

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -4,7 +4,7 @@ LOCAL_MQTT_USER_NAME = None
 GW_MQTT_BROKER_ADDRESS = "mqtt.eclipseprojects.io"
 GW_MQTT_USER_NAME = None
 
-ATN_G_NODE_ALIAS = "dwtest.isone.nh.orange.1"
+WORLD_ROOT_ALIAS = "dwtest"
 
 LOCAL_MQTT_MESSAGE_DELTA_S = 0.4
 GW_MQTT_MESSAGE_DELTA = 0.4


### PR DESCRIPTION
The primary `ear` function is managing the first step of data persistence in the cloud. This functionality does not belong in the SCADA repo.

All messages between the `Atn` and the `Scada` need to include the `FromGNodeAlias` and `FromGNodeId` in order for the ear to validate and organize data from multiple houses.  This meant updating a number of the existing messages: 
  - `gt.sh.status` 100 -> 110
  - `gt.sh.cli.atn.cmd`  100 -> 110
  - `gt.sh.cli.scada.response` 100 -> 110
  -
  - `gt.dispatch` -> deprecated, and replaced by `gt.dispatch.boolean` (for dispatch commands of boolean actuators that come from the `atn`) and `gt.dispatch.boolean.local` (for dispatch commands on the local MQTT broker that come from the `HomeAlone` actor. 

This also involved stubbing out the concept of a GNode - via some json dicts in the `houses.json` file - and including the basic GNode information for the `Scada`, `Atn` and `TerminalAsset`.

Functionally, this means the `settings.py` file now has a `WORLD_ROOT_ALIAS` which gets used to select the correct collection of GNodes from houses.json. 

Finally, the `gt.sh.status.110` also has a StatusUid, and the scada keeps track of these in a dict called `status_to_store`. Right now it never actually writes these to disk _or_ flushes the dict. Which means we need to replace it with something at least slightly better at some point in the next month.

