### PR TITLE
Add docstring for home alone and gt.sh.status

### DIFF
--- a/gw_spaceheat/actors/home_alone.py
+++ b/gw_spaceheat/actors/home_alone.py
@@ -7,6 +7,11 @@ from schema.gt.gt_sh_status.gt_sh_status_maker import GtShStatus, GtShStatus_Mak
 
 
 class HomeAlone(ActorBase):
+    """HomeAlone is the offline degraded imitator of the AtomicTNode. It dispatches the 
+    SCADA actor whenever the SCADA's DispatchContract with its AtomicTNode is not alive.
+    The primary (but not only) reason for this will be loss of communications (i.e. router
+    down or cellular service down) between the home and the cloud. """
+
     MAIN_LOOP_MIN_TIME_S = 5
 
     def __init__(self, node: ShNode, logging_on=False):

--- a/gw_spaceheat/schema/gt/gt_sh_status/gt_sh_status.py
+++ b/gw_spaceheat/schema/gt/gt_sh_status/gt_sh_status.py
@@ -7,12 +7,17 @@ from schema.gt.gt_sh_status.gt_sh_status_base import (
 
 
 class GtShStatus(GtShStatusBase):
+    """Designed for the SCADA to send to the AtomicTNode every 5 minutes,
+    for supporting an AtomicTNode with the incremental state data needed for deciding
+    when to charge the big heating loads (boost elements, heat pumps)."""
+
     def check_for_errors(self):
         errors = self.derived_errors() + self.hand_coded_errors()
         if len(errors) > 0:
-            raise MpSchemaError(
-                f" Errors making making gt.sh.status.110 for {self}: {errors}"
-            )
+            raise MpSchemaError(f" Errors making making gt.sh.status.110 for {self}: {errors}")
 
     def hand_coded_errors(self):
-        return []
+        if self.ReportingPeriodS != 300:
+            return ["ReportingPeriodS must be 300"]
+        else:
+            return []


### PR DESCRIPTION
In VCharge days, there was a wired control loop from the room thermostat to the fan on the thermal storage room unit that had our controls on it. We inserted ourselves into that control loop (i.e., cut the wire, sensed the signal, and then passed it on). We did this so that we could sense the thermostat calls - we did not actually change the signals.

The VCharge 5-minute status message would just include how many seconds of heat call there had been (out of 300). 

The protocol between the VCharge Scada device and the rest of the VCharge was set at the beginning and never changed. The SCADA code was designed to never be changed, but was deeply flawed and so it was changed a fair amount. More importantly, we did not understand very well how to run a heating system, so there were things we naturally needed to change as we moved forward and understood better. This combination led to a lot of stress, lost time, and things not working as well as they could.

A lot of what has driven the development of the schema - and the concept of the dispatch contract - is an effort to be able to be ready for change, while still being extremely clear about the state of things. 

Note that the `gt.sh.status` is not counting how many seconds of heat call there has been. For one thing, circulator pumps (and fans) can have more than one speed. More importantly, clarity requires the ability to go back and evaluate the raw data - which does not happen easily if you only have manipulated data, especially if the underlying code is expected to change on a regular basis. I think this is well understood and generally practiced in distributed systems. 

I think the main purpose of the 5 minute status is for providing organizational structure to the AtomicTNode code. I.e. `this is the data you need to pay attention to, manipulate in various ways, and then use for rerunning your decision algorithms for bidding into the electricity markets and dispatching the big heating loads.`

Note that if we end up keeping the circulator pumps running sometimes even when a zonal temperature is above the homeowners temp setpoint (i.e. nonstandard thermostatic behavior), and we maintain the notion that all dispatch of physical things is done at the command of the AtomicTNode  (which I think is the correct approach), then this thermostatic control loop will happen outside of the `gt.sh.status` message - just like the power reporting.

I think I use the word `dispatch` to clarify that it is a command to change the state of a physical device that the SCADA can control. Obviously computers themselves are also physical devices, but I am distinguishing between a command to, say, go back to an old firmware version and a command to turn on the boost element or a circulator pump.

The word `status` is massively context dependent. Reserving it (mostly ... with the `sh` for space heat in front) for the data needed for deciding what to do with dispatching the big loads is prioritizing the context: turning on and off big loads is the primary thing this Scada does. Not also that the stub `cli` code in the Atn uses the word `status` as well - with a different context. In that case, the context is `what does George want to see in real time`. 

I am open to a different name for `gt.sh.status` if you have thoughts. 
