### PR TITLE
try to get logging always UTC ISO format

### DIFF
--- a/gw_spaceheat/actors/utils.py
+++ b/gw_spaceheat/actors/utils.py
@@ -1,4 +1,4 @@
-import datetime
+import pendulum
 import enum
 import time
 from typing import NamedTuple, Optional, Any
@@ -55,7 +55,7 @@ class MessageSummary:
         topic: str,
         payload_object: Any = None,
         broker_flag=" ",
-        timestamp: Optional[datetime.datetime] = None,
+        timestamp: Optional[pendulum.datetime] = None,
     ) -> str:
         """
         Formats a single line summary of message receipt/publication.
@@ -66,14 +66,14 @@ class MessageSummary:
             topic: The destination or source topic.
             payload_object: The payload of the message.
             broker_flag: "*" for the "gw" broker.
-            timestamp: "datetime.datetime.now() by default.
+            timestamp: "pendulum.now("UTC") by default.
 
         Returns:
             Formatted string.
         """
         try:
             if timestamp is None:
-                timestamp = datetime.datetime.now()
+                timestamp = pendulum.now("UTC")
             direction = direction[:3].strip().upper()
             if direction in ["OUT", "SND"]:
                 arrow = "->"

--- a/gw_spaceheat/helpers.py
+++ b/gw_spaceheat/helpers.py
@@ -1,6 +1,5 @@
 import os
 import re
-import time
 
 import pendulum
 from dotenv import load_dotenv
@@ -23,5 +22,5 @@ def get_secret(key):
 
 
 def log_time() -> str:
-    time_utc = pendulum.from_timestamp(time.time())
-    return time_utc.strftime("%Y-%m-%d %H:%M:%S")
+    time_utc = pendulum.now("UTC")
+    return time_utc.isoformat()


### PR DESCRIPTION
I'd like all of our log reports to use UTC time. 

In general I like using pendulum over datetime; it does a better job as far as I am concerned about being clear regarding timezones. In particular it does not default to naive time but always includes a timezone in its datetime objects.

I tried to update MessageSummary to do this, replacing datetime.datetime.now() with pendulum.now("UTC"). But strangely, the message logs using MessageSummary are still coming up in local time.

e.g.
2022-08-11T10:48:46.552462  IN   w.isone.ct.newhaven.orange1 [ETC]

when  shortly after that
pendulum.now("UTC").isoformat() returns
'2022-08-11T14:49:03.556545+00:00'

I am also unfamiliar with creating classes without inits etc as you did with MessageSummary. I figure this is worth a chat.
