### PR TITLE
Allow tests to run on the pi. 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: canastro/copy-file-action@master
         with:
           source: "test/config/.env-ci"
-          target: ".env"
+          target: "test/.env-gw-spaceheat-test"
       - name: Run tests with pytest under coverage
         run: coverage run -m pytest
       - name: Upload coverage data

--- a/test/.env-gw-spaceheat-test-pi
+++ b/test/.env-gw-spaceheat-test-pi
@@ -1,0 +1,7 @@
+# Minimal environment variables required to run pytest on The EmonPi. 
+
+SCADA_LOCAL_MQTT__USERNAME = "emonpi"
+SCADA_LOCAL_MQTT__PASSWORD = "emonpimqtt2016"
+
+SCADA_GRIDWORKS_MQTT__USERNAME = "emonpi"
+SCADA_GRIDWORKS_MQTT__PASSWORD = "emonpimqtt2016"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,20 +2,30 @@
 
 import contextlib
 import os
+from pathlib import Path
 from typing import Generator
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
+import dotenv
 
 from config import ScadaSettings
 from test.utils import flush_all
 
+TEST_DOTENV_PATH = "test/.env-gw-spaceheat-test"
+TEST_DOTENV_PATH_VAR = "GW_SPACEHEAT_TEST_DOTENV_PATH"
+
 
 class CleanScadaEnv:
-    """Context manager for monkeypatched environment with all vars starting with SCADA_ removed. Usage:
+    """Context manager for monkeypatched environment with all vars starting with SCADA_ removed and replaced by
+    the contents of the test env file, if specified. Usage:
     >>> os.environ["SCADA_WORLD_ROOT_ALIAS"] = "foo"
     >>> with CleanScadaEnv().context() as mpatch:
     ...     assert os.getenv("SCADA_WORLD_ROOT_ALIAS") == "dw1"
+
+    The default test env file is test/.env-gw-spaceheat-test. This path can be overridden with the environment variable
+    GW_SPACEHEAT_TEST_DOT_ENV_PATH. The test env file will be ignored if the GW_SPACEHEAT_TEST_DOT_ENV_PATH environment
+    variable exists but is empty or the specified path does not exist.
     """
 
     def __init__(self, world: str = "dw1", prefix: str = ScadaSettings.Config.env_prefix):
@@ -24,7 +34,7 @@ class CleanScadaEnv:
 
     @contextlib.contextmanager
     def context(self) -> Generator[MonkeyPatch, None, None]:
-        """"""
+        """Produce monkeypatch context manager from this object"""
         mpatch = MonkeyPatch()
         with mpatch.context() as m:
             for env_var in os.environ:
@@ -32,6 +42,13 @@ class CleanScadaEnv:
                     m.delenv(env_var)
             if self.world:
                 m.setenv(f"{self.prefix}WORLD_ROOT_ALIAS", self.world)
+            test_dotenv_file = os.getenv(TEST_DOTENV_PATH_VAR)
+            if test_dotenv_file is None:
+                test_dotenv_file = TEST_DOTENV_PATH
+            if test_dotenv_file:
+                test_dotenv_path = Path(test_dotenv_file)
+                if test_dotenv_path.exists():
+                    dotenv.load_dotenv(dotenv_path=test_dotenv_path)
             yield m
 
 
@@ -43,16 +60,20 @@ def flush_local_registries():
 @pytest.fixture(autouse=True)
 def clean_scada_env(request) -> Generator[MonkeyPatch, None, None]:
     """Automatically used fixture producing monkeypatched environment with all vars starting SCADA_ removed and then
-    setting enviroment variable to SCADA_WORLD_ALIAS_ROOT set to 'dw1'.
+    setting enviroment variable to SCADA_WORLD_ALIAS_ROOT set to 'dw1'. If the test dotenv file
+    (.test/.env-gw-spaceheat-test or the value of the environment variable TEST_DOTENV_PATH_VAR) exists, its contents
+    will be used to set the environment after cleaning previously existing SCDADA_ vars.
 
     Note that this fixture is run before _every_ test.
 
-    To customize the behavior of this fixture pass it explicitly to a test and parametrize it. For example to run the
-    test with SCADA_WORLD_ROOT set to "trappist-1e":
+    To customize the behavior of this fixture use the test dotenv file as described above or pass the fixture explicitly
+    to a test and parametrize it. For example to run the test with SCADA_WORLD_ROOT set to "trappist-1e":
 
         @pytest.mark.parametrize("clean_scada_env", [("trappist-1e",)], indirect=True)
         def test_something(clean_scada_env):
             assert os.getenv("SCADA_WORLD_ROOT_ALIAS") == "trappist-1e"
+
+
     """
     param = getattr(request, "param", ("dw1", "SCADA_"))
     with CleanScadaEnv(

--- a/test/test_actors2/test_scada2.py
+++ b/test/test_actors2/test_scada2.py
@@ -217,7 +217,7 @@ async def test_scada2_relay_dispatch(tmp_path, monkeypatch):
             )
             status = scada2._data.make_status(int(time.time()))
             assert len(status.SimpleTelemetryList) == 1
-            assert status.SimpleTelemetryList[0].ValueList == [0, 1]
+            assert status.SimpleTelemetryList[0].ValueList[-1] == 1
             assert status.SimpleTelemetryList[0].ShNodeAlias == relay2.alias
             assert (
                 status.SimpleTelemetryList[0].TelemetryName == TelemetryName.RELAY_STATE

--- a/test/test_actors2/test_scada2.py
+++ b/test/test_actors2/test_scada2.py
@@ -264,7 +264,7 @@ async def test_scada2_relay_dispatch(tmp_path, monkeypatch):
             status = atn.latest_status_payload
             assert isinstance(status, GtShStatus)
             assert len(status.SimpleTelemetryList) == 1
-            assert status.SimpleTelemetryList[0].ValueList == [0, 1]
+            assert status.SimpleTelemetryList[0].ValueList[-1] == 1
             assert status.SimpleTelemetryList[0].ShNodeAlias == relay2.alias
             assert status.SimpleTelemetryList[0].TelemetryName == TelemetryName.RELAY_STATE
             assert len(status.BooleanactuatorCmdList) == 1

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -26,7 +26,7 @@ def test_mqtt_client_settings():
     assert settings.password.get_secret_value() == password
 
 
-@pytest.mark.parametrize("clean_scada_env", [("",)], indirect=True)
+@pytest.mark.parametrize("clean_scada_env", [("", False)], indirect=True)
 def test_scada_settings_defaults(clean_scada_env):
     """Test ScadaSettings defaults"""
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,5 +1,4 @@
 """Test config module"""
-import os
 import textwrap
 from pathlib import Path
 
@@ -26,7 +25,6 @@ def test_mqtt_client_settings():
     assert settings.password.get_secret_value() == password
 
 
-@pytest.mark.parametrize("clean_scada_env", [("", False)], indirect=True)
 def test_scada_settings_defaults(clean_scada_env):
     """Test ScadaSettings defaults"""
 
@@ -53,10 +51,8 @@ def test_scada_settings_defaults(clean_scada_env):
     assert settings.local_mqtt.password.get_secret_value() == ""
 
 
-def test_scada_settings_from_env(monkeypatch):
+def test_scada_settings_from_env(monkeypatch, clean_scada_env):
     """Verify settings loaded from env as expected. """
-    monkeypatch.delenv("SCADA_WORLD_ROOT_ALIAS")
-    assert "SCADA_WORLD_ROOT_ALIAS" not in os.environ
     with pytest.raises(pydantic.error_wrappers.ValidationError):
         ScadaSettings()
     world = "Foo"
@@ -85,9 +81,8 @@ def test_scada_settings_from_env(monkeypatch):
     assert settings.gridworks_mqtt.password.get_secret_value() == exp["SCADA_GRIDWORKS_MQTT__PASSWORD"]
 
 
-def test_scada_settings_from_dotenv(monkeypatch, tmp_path):
+def test_scada_settings_from_dotenv(monkeypatch, tmp_path, clean_scada_env):
     """Verify settings loaded from .env file as expected. """
-    monkeypatch.delenv("SCADA_WORLD_ROOT_ALIAS")
     env_file = Path(tmp_path) / ".env"
     settings = ScadaSettings(world_root_alias="1", _env_file=env_file)
     assert settings.seconds_per_report == 300
@@ -118,7 +113,7 @@ def test_scada_settings_from_dotenv(monkeypatch, tmp_path):
     assert settings.local_mqtt.password.get_secret_value() == password
 
 
-def test_scada_settings_from_env_and_dotenv(monkeypatch, tmp_path):
+def test_scada_settings_from_env_and_dotenv(monkeypatch, tmp_path, clean_scada_env):
     """Verify settings loaded from both environment variables and .env and as expected - environment variables
     take precedence"""
     env = dict(

--- a/wiki/docs/setting-up-the-pi.md
+++ b/wiki/docs/setting-up-the-pi.md
@@ -62,17 +62,18 @@ Use ssh -A pi@LAN to bring my keys
 
 In /home/pi
 
-git clone https://github.com/thegridelectric/gw-scada-spaceheat-python.git
+    git clone https://github.com/thegridelectric/gw-scada-spaceheat-python.git
+    cd gw-scada-spaceheat-python/gw_spaceheat/
+    python -m venv venv
+    source venv/bin/activate
+    export TMPDIR=/home/pi/tmp
+    pip install -r requirements/drivers.txt
 
-cd gw-scada-spaceheat-python/gw_spaceheat/
+Test with: 
 
-python -m venv venv
-
-source venv/bin/activate
-
-export TMPDIR=/home/pi/tmp
-
-pip install -r requirements/drivers.txt
+    export PYTHONPATH=gw_spaceheat
+    export GW_SPACEHEAT_TEST_DOTENV_PATH=test/.env-gw-spaceheat-test-pi
+    pytest
 
 # RANDOM NOTES
 


### PR DESCRIPTION
The pi needs specific passwords for local mqtt broker and possibly other settings. This change makes tests by default get their environment from `test/.env-gw-spaceheat-test-pi` (named not accidentally clash with some other .env file a user might have created). A test dotenv file suitable for using with default pi configuration is also provided. Tests can be run from the virtual environment with: 

```
cd gw-scada-spaceheat-python
export PYTHONPATH=gw_spaceheat
export GW_SPACEHEAT_TEST_DOTENV_PATH=test/.env-gw-spaceheat-test-pi
pytest
```

 