### PR TITLE
Logging: rolling file handler, usage python logging module instead of print. 

### DIFF
--- a/gw_spaceheat/actors/utils.py
+++ b/gw_spaceheat/actors/utils.py
@@ -1,7 +1,7 @@
 import pendulum
 import enum
 import time
-from typing import NamedTuple, Optional, Any
+from typing import NamedTuple
 
 
 class QOS(enum.IntEnum):
@@ -57,61 +57,3 @@ def responsive_sleep(
     return getattr(obj, running_field_name)
 
 
-class MessageSummary:
-    """Helper class for formating message summaries message receipt/publication single line summaries."""
-
-    DEFAULT_FORMAT = (
-        "{timestamp}  {direction:4s}  {actor_alias:33s}  {broker_flag}  {arrow:2s}  {topic:80s}"
-        "  {payload_type}"
-    )
-
-    @classmethod
-    def format(
-        cls,
-        direction: str,
-        actor_alias: str,
-        topic: str,
-        payload_object: Any = None,
-        broker_flag=" ",
-        timestamp: Optional[pendulum.datetime] = None,
-    ) -> str:
-        """
-        Formats a single line summary of message receipt/publication.
-
-        Args:
-            direction: "IN" or "OUT"
-            actor_alias: The node alias of the sending or receiving actor.
-            topic: The destination or source topic.
-            payload_object: The payload of the message.
-            broker_flag: "*" for the "gw" broker.
-            timestamp: "pendulum.now("UTC") by default.
-
-        Returns:
-            Formatted string.
-        """
-        try:
-            if timestamp is None:
-                timestamp = pendulum.now("UTC")
-            direction = direction[:3].strip().upper()
-            if direction in ["OUT", "SND"]:
-                arrow = "->"
-            elif direction.startswith("IN") or direction.startswith("RCV"):
-                arrow = "<-"
-            else:
-                arrow = "? "
-            if hasattr(payload_object, "__class__"):
-                payload_str = payload_object.__class__.__name__
-            else:
-                payload_str = type(payload_object)
-            return cls.DEFAULT_FORMAT.format(
-                timestamp=timestamp.isoformat(),
-                direction=direction,
-                actor_alias=actor_alias,
-                broker_flag=broker_flag,
-                arrow=arrow,
-                topic=f"[{topic}]",
-                payload_type=payload_str,
-            )
-        except Exception as e:
-            print(f"ouch got {e}")
-            return ""

--- a/gw_spaceheat/actors2/scada2.py
+++ b/gw_spaceheat/actors2/scada2.py
@@ -232,7 +232,7 @@ class Scada2(ScadaInterface, Proactor):
         )
 
     async def _derived_process_message(self, message: Message):
-        self._logger.path("++Scada2._derived_process_message {src}/{type}", src=message.header.src, type=message.header.message_type)
+        self._logger.path("++Scada2._derived_process_message %s/%s", message.header.src, message.header.message_type)
         path_dbg = 0
         from_node = self._layout.node(message.header.src, None)
         if isinstance(message.payload, GsPwr):
@@ -282,7 +282,7 @@ class Scada2(ScadaInterface, Proactor):
             raise ValueError(
                 f"There is not handler for mqtt message payload type [{type(message.payload)}]"
             )
-        self._logger.path("--Scada2._derived_process_message  path:0x{path_dbg:08X}", path_dbg=path_dbg)
+        self._logger.path("--Scada2._derived_process_message  path:0x%08X", path_dbg)
 
     # TODO: Clean this up
     # noinspection PyProtectedMember
@@ -298,7 +298,7 @@ class Scada2(ScadaInterface, Proactor):
     async def _derived_process_mqtt_message(
         self, message: Message[MQTTReceiptPayload], decoded: Any
     ):
-        self._logger.path("++Scada2._derived_process_mqtt_message {topic}", topic=message.payload.message.topic)
+        self._logger.path("++Scada2._derived_process_mqtt_message %s", message.payload.message.topic)
         path_dbg = 0
         if message.payload.client_name != self.GRIDWORKS_MQTT:
             raise ValueError(
@@ -319,7 +319,7 @@ class Scada2(ScadaInterface, Proactor):
                 f"There is not handler for mqtt message payload type [{type(decoded)}]"
                 f"Received\n\t topic: [{message.payload.message.topic}]"
             )
-        self._logger.path("--Scada2._derived_process_mqtt_message  path:0x{path_dbg:08X}", path_dbg=[path_dbg])
+        self._logger.path("--Scada2._derived_process_mqtt_message  path:0x%08X", path_dbg)
 
     def _process_telemetry(self, message: Message, decoded: GtTelemetry):
         from_node = self._layout.node(message.header.src)

--- a/gw_spaceheat/command_line_utils.py
+++ b/gw_spaceheat/command_line_utils.py
@@ -85,14 +85,13 @@ def run_nodes(
 def run_nodes_main(
     argv: Optional[Sequence[str]] = None,
     default_nodes: Optional[Sequence[str]] = None,
-    update_root_logger: bool = True,
     dbg: Optional[Dict] = None,
 ) -> None:
     """Load and run the configured Nodes. If dbg is not None it will be populated with the actor objects."""
     args = parse_args(argv, default_nodes=default_nodes)
     settings = ScadaSettings(_env_file=dotenv.find_dotenv(args.env_file))
     settings.paths.mkdirs()
-    setup_logging(args, settings, update_root_logger)
+    setup_logging(args, settings)
     run_nodes(args.nodes, settings, load_house.load_all(settings), dbg=dbg)
 
 
@@ -135,12 +134,11 @@ async def run_async_actors(
 async def run_async_actors_main(
     argv: Optional[Sequence[str]] = None,
     default_nodes: Optional[Sequence[str]] = None,
-    update_root_logger: bool = True,
 ):
     args = parse_args(argv, default_nodes=default_nodes)
     settings = ScadaSettings(_env_file=dotenv.find_dotenv(args.env_file))
     settings.paths.mkdirs()
-    setup_logging(args, settings, update_root_logger)
+    setup_logging(args, settings)
     layout = load_house.load_all(settings)
     if not args.nodes:
         args.nodes = [

--- a/gw_spaceheat/command_line_utils.py
+++ b/gw_spaceheat/command_line_utils.py
@@ -1,12 +1,12 @@
 import importlib
 import sys
 import argparse
-import logging
 from typing import Optional, Sequence, Dict, Callable, Tuple, List
 
 import dotenv
 
 import load_house
+from logging_setup import setup_logging
 from actors.strategy_switcher import strategy_from_node
 from actors2 import Scada2
 from config import ScadaSettings
@@ -30,7 +30,9 @@ def add_default_args(
             "Pass empty string in quotation marks to suppress use of .env file."
         ),
     )
-    parser.add_argument("-l", "--log", action="store_true", help="Turn logging on.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Increase logging verbosity")
+    parser.add_argument("--message-summary", action="store_true", help="Turn on message summary logging")
+
     parser.add_argument(
         "-n",
         "--nodes",
@@ -55,17 +57,6 @@ def parse_args(
         ),
         default_nodes=default_nodes,
     ).parse_args(sys.argv[1:] if argv is None else argv, namespace=args)
-
-
-def setup_logging(args: argparse.Namespace, settings: ScadaSettings) -> None:
-    """Setup python logging based on parsed command line args"""
-    if args.log or settings.logging_on:
-        settings.logging_on = True
-        level = "DEBUG"
-    else:
-        level = "INFO"
-    logging.basicConfig(level=level, format=LOGGING_FORMAT)
-
 
 def run_nodes(
     aliases: Sequence[str], settings: ScadaSettings, layout: HardwareLayout, dbg: Optional[Dict] = None
@@ -94,13 +85,14 @@ def run_nodes(
 def run_nodes_main(
     argv: Optional[Sequence[str]] = None,
     default_nodes: Optional[Sequence[str]] = None,
+    update_root_logger: bool = True,
     dbg: Optional[Dict] = None,
 ) -> None:
     """Load and run the configured Nodes. If dbg is not None it will be populated with the actor objects."""
     args = parse_args(argv, default_nodes=default_nodes)
     settings = ScadaSettings(_env_file=dotenv.find_dotenv(args.env_file))
     settings.paths.mkdirs()
-    setup_logging(args, settings)
+    setup_logging(args, settings, update_root_logger)
     run_nodes(args.nodes, settings, load_house.load_all(settings), dbg=dbg)
 
 
@@ -143,11 +135,12 @@ async def run_async_actors(
 async def run_async_actors_main(
     argv: Optional[Sequence[str]] = None,
     default_nodes: Optional[Sequence[str]] = None,
+    update_root_logger: bool = True,
 ):
     args = parse_args(argv, default_nodes=default_nodes)
     settings = ScadaSettings(_env_file=dotenv.find_dotenv(args.env_file))
     settings.paths.mkdirs()
-    setup_logging(args, settings)
+    setup_logging(args, settings, update_root_logger)
     layout = load_house.load_all(settings)
     if not args.nodes:
         args.nodes = [

--- a/gw_spaceheat/config.py
+++ b/gw_spaceheat/config.py
@@ -5,7 +5,13 @@ from typing import Optional, Dict
 import xdg
 from pydantic import BaseModel, BaseSettings, SecretStr, validator
 
+from logging_config import LoggingSettings, DEFAULT_BASE_NAME
+
 DEFAULT_ENV_FILE = ".env"
+DEFAULT_BASE_DIR = Path(DEFAULT_BASE_NAME)
+DEFAULT_NAME = "scada"
+DEFAULT_NAME_DIR = Path(DEFAULT_NAME)
+DEFAULT_LAYOUT_FILE = Path("hardware-layout.json")
 
 
 class MQTTClient(BaseModel):
@@ -17,11 +23,6 @@ class MQTTClient(BaseModel):
     bind_port: int = 0
     username: Optional[str] = None
     password: SecretStr = SecretStr("")
-
-
-DEFAULT_BASE_DIR = Path("gridworks")
-DEFAULT_NAME_DIR = Path("scada")
-DEFAULT_LAYOUT_FILE = Path("hardware-layout.json")
 
 
 class Paths(BaseModel):
@@ -88,7 +89,6 @@ class Paths(BaseModel):
         self.config_dir.mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
         self.log_dir.mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
 
-
 class ScadaSettings(BaseSettings):
     """Settings for the GridWorks scada."""
     local_mqtt: MQTTClient = MQTTClient()
@@ -96,15 +96,14 @@ class ScadaSettings(BaseSettings):
     paths: Paths = None
     seconds_per_report: int = 300
     async_power_reporting_threshold = 0.02
-    logging_on: bool = False
-    log_message_summary: bool = False
+    logging: LoggingSettings = LoggingSettings()
 
     class Config:
         env_prefix = "SCADA_"
         env_nested_delimiter = "__"
 
     @validator("paths", always=True)
-    def get_relative_path(cls, v: Paths) -> Paths:
+    def get_paths(cls, v: Paths) -> Paths:
         if v is None:
             v = Paths()
         return v

--- a/gw_spaceheat/logging_config.py
+++ b/gw_spaceheat/logging_config.py
@@ -1,0 +1,106 @@
+import logging
+import time
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Iterable
+
+from pydantic import BaseModel, validator
+
+DEFAULT_LOGGING_FORMAT = "%(asctime)s %(message)s"
+DEFAULT_FRACTIONAL_SECOND_FORMAT = "%s.%03d"
+DEFAULT_LOG_FILE_NAME = "scada.log"
+DEFAULT_BYTES_PER_LOG_FILE = 2 * 1024 * 1024
+DEFAULT_NUM_LOG_FILES = 10
+DEFAULT_BASE_NAME = "gridworks"
+
+
+class FormatterSettings(BaseModel):
+    fmt: str = DEFAULT_LOGGING_FORMAT
+    datefmt: str = ""
+    default_msec_format: str = DEFAULT_FRACTIONAL_SECOND_FORMAT
+
+    def create(self) -> logging.Formatter:
+        formatter = logging.Formatter(
+            fmt=self.fmt,
+            datefmt=self.datefmt,
+        )
+        formatter.default_msec_format = self.default_msec_format
+        formatter.converter = time.gmtime
+        return formatter
+
+class RotatingFileHandlerSettings(BaseModel):
+    filename: str = DEFAULT_LOG_FILE_NAME
+    bytes_per_log_file: int = DEFAULT_BYTES_PER_LOG_FILE
+    num_log_files: int = DEFAULT_NUM_LOG_FILES
+    level: int = logging.NOTSET
+
+    def create(self, log_dir: Path | str, formatter: logging.Formatter) -> RotatingFileHandler:
+        handler = logging.handlers.RotatingFileHandler(
+            filename=log_dir / self.filename,
+            maxBytes=self.bytes_per_log_file,
+            backupCount=self.num_log_files-1,
+        )
+        handler.setFormatter(formatter)
+        if self.level != logging.NOTSET:
+            handler.setLevel(self.level)
+        return handler
+
+
+class LoggerLevels(BaseModel):
+    general: int | str = logging.WARNING
+    message_summary: int | str = logging.WARNING
+    lifecycle: int | str = logging.INFO
+    comm_event: int | str = logging.INFO
+
+    def qualified_logger_names(self, base_log_name: str) -> dict[str, str]:
+        return {
+            field_name: f"{base_log_name}.{field_name}" for field_name in self.__fields__
+        }
+
+    def _logger_levels(self, base_log_name: str, fields: Iterable[str]) -> dict[str, dict[str, int]]:
+        return {
+            f"{base_log_name}.{field_name}": dict(level=getattr(self, field_name)) for field_name in fields
+        }
+
+    def logger_names_to_levels(self, base_log_name: str) -> dict[str, dict[str, int]]:
+        return self._logger_levels(base_log_name, self.__fields__)
+
+    def set_logger_names_to_levels(self, base_log_name: str) -> dict[str, dict[str, int]]:
+        return self._logger_levels(base_log_name, self.__fields_set__)
+
+    @validator("*")
+    def logging_level_str_to_int(cls, v: int | str) -> int:
+        # noinspection PyBroadException
+        try:
+            int_v = int(v)
+        except:
+            if hasattr(v, "upper"):
+                v = v.upper()
+            int_v = logging.getLevelName(v)
+            if not isinstance(int_v, int):
+                raise ValueError(
+                    f"Could not convert level ({v}/{type(v)}) to an int, either by cast or by logging.getLevelName()")
+        return int_v
+
+class LoggingSettings(BaseModel):
+    base_log_name: str = DEFAULT_BASE_NAME
+    base_log_level: int = logging.INFO
+    levels: LoggerLevels = LoggerLevels()
+    formatter: FormatterSettings = FormatterSettings()
+    file_handler: RotatingFileHandlerSettings = RotatingFileHandlerSettings()
+
+    def qualified_logger_names(self) -> dict[str, str]:
+        return self.levels.qualified_logger_names(self.base_log_name)
+
+    def logger_levels(self) -> dict[str, dict[str, int]]:
+        return self.levels.logger_names_to_levels(self.base_log_name)
+
+    def set_logger_levels(self) -> dict[str, dict[str, int]]:
+        return self.levels.set_logger_names_to_levels(self.base_log_name)
+
+    def verbose(self) -> bool:
+        return self.levels.general <= logging.INFO
+
+    def message_summary_enabled(self) -> bool:
+        return self.levels.message_summary <= logging.INFO
+

--- a/gw_spaceheat/logging_setup.py
+++ b/gw_spaceheat/logging_setup.py
@@ -31,7 +31,6 @@ def format_exceptions(exceptions: list[BaseException]) -> str:
 def setup_logging(
         args: argparse.Namespace,
         settings: ScadaSettings,
-        update_root_logger: bool = True,
         errors: Optional[list[BaseException]] = None,
 ) -> None:
     """Get python logging config based on parsed command line args, defaults, environment variables and logging config file.
@@ -87,17 +86,13 @@ def setup_logging(
             except BaseException as e:
                 errors.append(e)
 
-        # Turn on logging in base logger, with level and handlers, as requested
-        if update_root_logger:
-            base_logger_name = ""
-        else:
-            base_logger_name = settings.logging.base_log_name
-        base_logger = logging.getLogger(base_logger_name)
-        base_logger.setLevel(logging.INFO)
+        # Turn on logging in root logger, with level and handlers, as requested
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logging.INFO)
         for handler in [screen_handler, file_handler]:
             if handler is not None:
                 try:
-                    base_logger.addHandler(handler)
+                    root_logger.addHandler(handler)
                 except BaseException as e:
                     errors.append(e)
         config_finished = True

--- a/gw_spaceheat/logging_setup.py
+++ b/gw_spaceheat/logging_setup.py
@@ -1,0 +1,120 @@
+import argparse
+import logging
+import logging.config
+import syslog
+import traceback
+from typing import Optional
+
+from config import ScadaSettings
+
+def format_exceptions(exceptions: list[BaseException]) -> str:
+    s = ""
+    # noinspection PyBroadException
+    try:
+        if exceptions:
+            for i, exception in enumerate(exceptions):
+                s += f"++ Exception {i + 1:2d} / {len(exceptions)} ++++++++++++++++++++++++++++++++++++++++++++++++++++\n"
+                try:
+                    s += "".join(traceback.format_exception(exception))
+                    s += "\n"
+                except BaseException as e:
+                    # noinspection PyBroadException
+                    try:
+                        s += f"ERROR formatting traceback for {e}\n"
+                    except:
+                        s += "UNEXPECTED ERROR formatting exception.\n"
+                s += f"-- Exception {i + 1:2d} / {len(exceptions)} ----------------------------------------------------\n\n"
+    except:
+        s += "UNEXPECTED ERROR formatting exception.\n"
+    return s
+
+def setup_logging(
+        args: argparse.Namespace,
+        settings: ScadaSettings,
+        update_root_logger: bool = True,
+        errors: Optional[list[BaseException]] = None,
+) -> None:
+    """Get python logging config based on parsed command line args, defaults, environment variables and logging config file.
+
+    The order of precedence is:
+
+        1. Command line arguments
+        2. Environment
+        3. Defaults
+
+    """
+    if errors is None:
+        errors: list[BaseException] = []
+    else:
+        errors.clear()
+    config_finished = False
+    try:
+        # Take any arguments from command line
+        try:
+            if getattr(args, "verbose", None):
+                settings.logging.levels.general = logging.INFO
+            if getattr(args, "message_summary", None):
+                settings.logging.levels.message_summary = logging.INFO
+        except BaseException as e:
+            errors.append(e)
+
+        # Create formatter from settings
+        try:
+            formatter = settings.logging.formatter.create()
+        except BaseException as e:
+            formatter = None
+            errors.append(e)
+
+        # Create handlers from settings
+        try:
+            screen_handler = logging.StreamHandler()
+            if formatter is not None:
+                screen_handler.setFormatter(formatter)
+        except BaseException as e:
+            screen_handler = None
+            errors.append(e)
+        try:
+            file_handler = settings.logging.file_handler.create(settings.paths.log_dir, formatter)
+        except BaseException as e:
+            file_handler = None
+            errors.append(e)
+
+        # Set application logger levels
+        for logger_name, logger_settings in settings.logging.logger_levels().items():
+            try:
+                logger = logging.getLogger(logger_name)
+                logger.setLevel(logger_settings["level"])
+            except BaseException as e:
+                errors.append(e)
+
+        # Turn on logging in base logger, with level and handlers, as requested
+        if update_root_logger:
+            base_logger_name = ""
+        else:
+            base_logger_name = settings.logging.base_log_name
+        base_logger = logging.getLogger(base_logger_name)
+        base_logger.setLevel(logging.INFO)
+        for handler in [screen_handler, file_handler]:
+            if handler is not None:
+                try:
+                    base_logger.addHandler(handler)
+                except BaseException as e:
+                    errors.append(e)
+        config_finished = True
+    except BaseException as e:
+        config_finished = False
+        errors.append(e)
+    finally:
+        # Try to tell user if something went wrong
+        if errors:
+            # noinspection PyBroadException
+            try:
+                s = "ERROR in setup_logging():\n" + format_exceptions(errors)
+                if config_finished:
+                    logging.error(s)
+                else:
+                    syslog.syslog(s)
+                    print(s)
+            except:
+                pass
+

--- a/gw_spaceheat/logging_setup.py
+++ b/gw_spaceheat/logging_setup.py
@@ -52,6 +52,7 @@ def setup_logging(
         try:
             if getattr(args, "verbose", None):
                 settings.logging.levels.general = logging.INFO
+                settings.logging.levels.message_summary = logging.DEBUG
             if getattr(args, "message_summary", None):
                 settings.logging.levels.message_summary = logging.INFO
         except BaseException as e:

--- a/gw_spaceheat/proactor/__init__.py
+++ b/gw_spaceheat/proactor/__init__.py
@@ -27,17 +27,19 @@ from proactor.sync_thread import (
     SyncAsyncQueueWriter,
     SyncAsyncInteractionThread,
 )
+from proactor.logger import ProactorLogger
 
 __all__ = [
+    "AsyncQueueWriter",
+    "Communicator",
+    "CommunicatorInterface",
     "Header",
     "Message",
-    "CommunicatorInterface",
-    "Communicator",
+    "MQTTCodec",
+    "Proactor",
+    "ProactorLogger",
     "Runnable",
     "ServicesInterface",
-    "Proactor",
-    "MQTTCodec",
-    "AsyncQueueWriter",
-    "SyncAsyncQueueWriter",
     "SyncAsyncInteractionThread",
+    "SyncAsyncQueueWriter",
 ]

--- a/gw_spaceheat/proactor/logger.py
+++ b/gw_spaceheat/proactor/logger.py
@@ -1,0 +1,144 @@
+import logging
+from typing import Optional, Any
+
+import pendulum
+
+class MessageSummary:
+    """Helper class for formating message summaries message receipt/publication single line summaries."""
+
+    DEFAULT_FORMAT = (
+        "{timestamp}  {direction:4s}  {actor_alias:33s}  {broker_flag}  {arrow:2s}  {topic:80s}"
+        "  {payload_type}"
+    )
+
+    @classmethod
+    def format(
+        cls,
+        direction: str,
+        actor_alias: str,
+        topic: str,
+        payload_object: Any = None,
+        broker_flag=" ",
+        timestamp: Optional[pendulum.datetime] = None,
+    ) -> str:
+        """
+        Formats a single line summary of message receipt/publication.
+
+        Args:
+            direction: "IN" or "OUT"
+            actor_alias: The node alias of the sending or receiving actor.
+            topic: The destination or source topic.
+            payload_object: The payload of the message.
+            broker_flag: "*" for the "gw" broker.
+            timestamp: "pendulum.now("UTC") by default.
+
+        Returns:
+            Formatted string.
+        """
+        try:
+            if timestamp is None:
+                timestamp = pendulum.now("UTC")
+            direction = direction[:3].strip().upper()
+            if direction in ["OUT", "SND"]:
+                arrow = "->"
+            elif direction.startswith("IN") or direction.startswith("RCV"):
+                arrow = "<-"
+            else:
+                arrow = "? "
+            if hasattr(payload_object, "__class__"):
+                payload_str = payload_object.__class__.__name__
+            else:
+                payload_str = type(payload_object)
+            return cls.DEFAULT_FORMAT.format(
+                timestamp=timestamp.isoformat(),
+                direction=direction,
+                actor_alias=actor_alias,
+                broker_flag=broker_flag,
+                arrow=arrow,
+                topic=f"[{topic}]",
+                payload_type=payload_str,
+            )
+        except Exception as e:
+            print(f"ouch got {e}")
+            return ""
+
+
+class ProactorLogger(logging.LoggerAdapter):
+
+    message_summary_logger: logging.Logger
+    lifecycle_logger: logging.Logger
+    comm_event_logger: logging.Logger
+
+    def __init__(self, general: str, message_summary:str, lifecycle: str, comm_event: str,  extra: Optional[dict] = None):
+        super().__init__(logging.getLogger(general), extra=extra)
+        self.message_summary_logger = logging.getLogger(message_summary)
+        self.lifecycle_logger = logging.getLogger(lifecycle)
+        self.comm_event_logger = logging.getLogger(comm_event)
+
+    @property
+    def general_enabled(self) -> bool:
+        return self.logger.isEnabledFor(logging.INFO)
+
+    @property
+    def message_summary_enabled(self) -> bool:
+        return self.message_summary_logger.isEnabledFor(logging.INFO)
+
+    @property
+    def path_enabled(self) -> bool:
+        return self.message_summary_logger.isEnabledFor(logging.DEBUG)
+
+    @property
+    def lifecycle_enabled(self) -> bool:
+        return self.lifecycle_logger.isEnabledFor(logging.INFO)
+
+    @property
+    def comm_event_enabled(self) -> bool:
+        return self.comm_event_logger.isEnabledFor(logging.INFO)
+
+    def message_summary(
+        self,
+        direction: str,
+        actor_alias: str,
+        topic: str,
+        payload_object: Any = None,
+        broker_flag=" ",
+        timestamp: Optional[pendulum.datetime] = None,
+    ) -> None:
+        if self.message_summary_logger.isEnabledFor(logging.INFO):
+            self.message_summary_logger.info(
+                MessageSummary.format(
+                    direction=direction,
+                    actor_alias=actor_alias,
+                    topic=topic,
+                    payload_object=payload_object,
+                    broker_flag=broker_flag,
+                    timestamp=timestamp
+                )
+            )
+
+    def path(self, msg: str, *args, **kwargs) -> None:
+        self.message_summary_logger.debug(msg, *args, **kwargs)
+
+    def lifecycle(self, msg: str, *args, **kwargs) -> None:
+        self.lifecycle_logger.info(msg, *args, **kwargs)
+
+    def comm_event(self, msg: str, *args, **kwargs) -> None:
+        self.comm_event_logger.info(msg, *args, **kwargs)
+
+    def general(self, msg: str, *args, **kwargs) -> None:
+        self.info(msg, *args, **kwargs)
+
+    @property
+    def general_logger(self) -> logging.Logger:
+        return self.logger
+
+    def __repr__(self):
+        return (
+            f"<{self.__class__.__name__} "
+            f"{self.logger.name}, "
+            f"{self.message_summary_logger.name}, "
+            f"{self.lifecycle_logger.name}, "
+            f"{self.comm_event_logger.name}>"
+    )
+
+

--- a/gw_spaceheat/proactor/proactor_implementation.py
+++ b/gw_spaceheat/proactor/proactor_implementation.py
@@ -127,7 +127,7 @@ class Proactor(ServicesInterface, Runnable):
         pass
 
     async def process_message(self, message: Message):
-        self._logger.path("++Proactor.process_message {}/{}", message.header.src, message.header.message_type)
+        self._logger.path("++Proactor.process_message %s/%s", message.header.src, message.header.message_type)
         path_dbg = 0
         self._logger.message_summary(
             "INx ",
@@ -153,10 +153,10 @@ class Proactor(ServicesInterface, Runnable):
         else:
             path_dbg |= 0x00000010
             await self._derived_process_message(message)
-        self._logger.path("--Proactor.process_message  path:0x{path_dbg:0x8X}", path_dbg=path_dbg)
+        self._logger.path("--Proactor.process_message  path:0x%08X", path_dbg)
 
     async def _process_mqtt_message(self, message: Message[MQTTReceiptPayload]):
-        self._logger.path("++Proactor._process_mqtt_message {src}/{type}", src=message.header.src, type=message.header.message_type)
+        self._logger.path("++Proactor._process_mqtt_message %s/%s", message.header.src, message.header.message_type)
         path_dbg = 0
         decoder = self._mqtt_codecs.get(message.payload.client_name, None)
         if decoder is not None:
@@ -167,7 +167,7 @@ class Proactor(ServicesInterface, Runnable):
             decoded = message.payload
         self._logger.message_summary("INq ", self.name, message.payload.message.topic, decoded)
         await self._derived_process_mqtt_message(message, decoded)
-        self._logger.path("--Proactor._process_mqtt_message  path:0x{path_dbg:08X}", path_dbg=path_dbg)
+        self._logger.path("--Proactor._process_mqtt_message  path:0x%08X", path_dbg)
 
     def _process_mqtt_connected(self, message: Message[MQTTConnectPayload]):
         self._mqtt_clients.subscribe_all(message.payload.client_name)

--- a/gw_spaceheat/proactor/proactor_implementation.py
+++ b/gw_spaceheat/proactor/proactor_implementation.py
@@ -3,15 +3,14 @@
 import asyncio
 import traceback
 from abc import ABC, abstractmethod
-from typing import Dict, List, Awaitable, Any, Optional
+from typing import Dict, List, Awaitable, Any, Optional, Iterable
 
 from paho.mqtt.client import MQTTMessageInfo
 
 import config
-from actors.utils import MessageSummary
+from proactor.logger import ProactorLogger
 from proactor.message import (
     Message,
-    KnownNames,
     MessageType,
     MQTTConnectPayload,
     MQTTReceiptPayload,
@@ -26,27 +25,6 @@ from proactor.proactor_interface import (
     CommunicatorInterface,
 )
 from proactor.sync_thread import AsyncQueueWriter
-
-
-def _print_tasks(loop_, tag="", tasks=None):
-    # TODO: Move this to some general debugging location
-    if tasks is None:
-        tasks = asyncio.all_tasks(loop_)
-    print(f"Tasks: {len(tasks)}  [{tag}]")
-
-    def _exception(task_):
-        try:
-            exception_ = task_.exception()
-        except asyncio.CancelledError as e:
-            exception_ = e
-        except asyncio.InvalidStateError:
-            exception_ = None
-        return exception_
-
-    for i, task in enumerate(tasks):
-        print(
-            f"\t{i+1}/{len(tasks)}  {task.get_name():20s}  done:{task.done()}   exception:{_exception(task)}  {task.get_coro()}"
-        )
 
 
 class MQTTCodec(ABC):
@@ -68,10 +46,12 @@ class Proactor(ServicesInterface, Runnable):
     _communicators: Dict[str, CommunicatorInterface]
     _stop_requested: bool
     _tasks: List[asyncio.Task]
+    _logger: ProactorLogger
 
     # TODO: Clean up loop control
-    def __init__(self, name: str = KnownNames.proactor.value):
+    def __init__(self, name: str, logger: ProactorLogger):
         self._name = name
+        self._logger = logger
         # TODO: Figure out and remove the deprecation warning this produces.
         self._loop = asyncio.get_event_loop()
         self._receive_queue = asyncio.Queue()
@@ -96,7 +76,7 @@ class Proactor(ServicesInterface, Runnable):
     def _encode_and_publish(
         self, client: str, topic: str, payload: Any, qos: int
     ) -> MQTTMessageInfo:
-        print(MessageSummary.format("OUTq", client, topic, payload))
+        self._logger.message_summary("OUTq", client, topic, payload)
         encoder = self._mqtt_codecs[client]
         return self._mqtt_clients.publish(client, topic, encoder.encode(payload), qos)
 
@@ -112,6 +92,7 @@ class Proactor(ServicesInterface, Runnable):
         return self._receive_queue
 
     async def process_messages(self):
+        # noinspection PyBroadException
         try:
             while not self._stop_requested:
                 message = await self._receive_queue.get()
@@ -119,14 +100,15 @@ class Proactor(ServicesInterface, Runnable):
                     await self.process_message(message)
                 self._receive_queue.task_done()
         # TODO: Clean this up
-        except Exception as e:
-            print(f"ERROR in process_message: {e}")
-            traceback.print_exc()
-            print("Stopping procator")
+        except:
+            self._logger.exception(f"ERROR in process_message")
+            self._logger.error("Stopping procator")
+            # noinspection PyBroadException
             try:
                 self.stop()
-            except Exception as e:
-                print(f"ERROR stopping proactor: {e}")
+            except:
+                self._logger.exception(f"ERROR stopping proactor")
+
     def start_tasks(self):
         self._tasks = [
             asyncio.create_task(self.process_messages(), name="process_messages")
@@ -145,17 +127,13 @@ class Proactor(ServicesInterface, Runnable):
         pass
 
     async def process_message(self, message: Message):
-        print(
-            f"++Proactor.process_message {message.header.src}/{message.header.message_type}"
-        )
+        self._logger.path("++Proactor.process_message {}/{}", message.header.src, message.header.message_type)
         path_dbg = 0
-        print(
-            MessageSummary.format(
-                "INx ",
-                self.name,
-                f"{message.header.src}/{message.header.message_type}",
-                message.payload,
-            )
+        self._logger.message_summary(
+            "INx ",
+            self.name,
+            f"{message.header.src}/{message.header.message_type}",
+            message.payload,
         )
         # TODO: be easier on the eyes
         if message.header.message_type == MessageType.mqtt_message.value:
@@ -175,12 +153,10 @@ class Proactor(ServicesInterface, Runnable):
         else:
             path_dbg |= 0x00000010
             await self._derived_process_message(message)
-        print(f"--Proactor.process_message  path:0x{path_dbg:08X}")
+        self._logger.path("--Proactor.process_message  path:0x{path_dbg:0x8X}", path_dbg=path_dbg)
 
     async def _process_mqtt_message(self, message: Message[MQTTReceiptPayload]):
-        print(
-            f"++Proactor._process_mqtt_message {message.header.src}/{message.header.message_type}"
-        )
+        self._logger.path("++Proactor._process_mqtt_message {src}/{type}", src=message.header.src, type=message.header.message_type)
         path_dbg = 0
         decoder = self._mqtt_codecs.get(message.payload.client_name, None)
         if decoder is not None:
@@ -189,13 +165,9 @@ class Proactor(ServicesInterface, Runnable):
         else:
             path_dbg |= 0x00000002
             decoded = message.payload
-        print(
-            MessageSummary.format(
-                "INq ", self.name, message.payload.message.topic, decoded
-            )
-        )
+        self._logger.message_summary("INq ", self.name, message.payload.message.topic, decoded)
         await self._derived_process_mqtt_message(message, decoded)
-        print(f"--Proactor._process_mqtt_message  path:0x{path_dbg:08X}")
+        self._logger.path("--Proactor._process_mqtt_message  path:0x{path_dbg:08X}", path_dbg=path_dbg)
 
     def _process_mqtt_connected(self, message: Message[MQTTConnectPayload]):
         self._mqtt_clients.subscribe_all(message.payload.client_name)
@@ -240,8 +212,8 @@ class Proactor(ServicesInterface, Runnable):
                     pass
 
     async def join(self):
-        print("++Proactor.join()")
-        _print_tasks(self._loop, "Proactor.join() - all tasks")
+        self._logger.lifecycle("++Proactor.join()")
+        self._logger.lifecycle(str_tasks(self._loop, "Proactor.join() - all tasks"))
         running: List[Awaitable] = self._tasks[:]
         for communicator in self._communicators.values():
             communicator_name = communicator.name
@@ -251,33 +223,30 @@ class Proactor(ServicesInterface, Runnable):
                         communicator.join(), name=f"{communicator_name}.join"
                     )
                 )
+        # noinspection PyBroadException
         try:
             while running:
-                _print_tasks(self._loop, "WAITING FOR", tasks=running)
+                self._logger.lifecycle(str_tasks(self._loop, "WAITING FOR", tasks=running))
                 done, running = await asyncio.wait(running, return_when="FIRST_COMPLETED")
-                _print_tasks(self._loop, tag="DONE", tasks=done)
-                _print_tasks(self._loop, tag="PENDING", tasks=running)
+                self._logger.lifecycle(str_tasks(self._loop, tag="DONE", tasks=done))
+                self._logger.lifecycle(str_tasks(self._loop, tag="PENDING", tasks=running))
                 for task in done:
-                    print("")
                     if exception := task.exception():
-                        print(f"EXCEPTION in task {task.get_name()}  {exception}")
-                        traceback.print_tb(exception.__traceback__)
-        except Exception as e:
-            print(f"ERROR in Proactor.join: {e}")
-            traceback.print_tb(e.__traceback__)
-        print("--Proactor.join()")
+                        self._logger.error(f"EXCEPTION in task {task.get_name()}  {exception}")
+                        self._logger.error(traceback.format_tb(exception.__traceback__))
+        except:
+            self._logger.exception("ERROR in Proactor.join")
+        self._logger.lifecycle("--Proactor.join()")
 
     def publish(self, client: str, topic: str, payload: bytes, qos: int):
         self._mqtt_clients.publish(client, topic, payload, qos)
 
     def send(self, message: Message):
-        print(
-            MessageSummary.format(
-                "OUTx",
-                message.header.src,
-                f"{message.header.dst}/{message.header.message_type}",
-                message.payload,
-            )
+        self._logger.message_summary(
+            "OUTx",
+            message.header.src,
+            f"{message.header.dst}/{message.header.message_type}",
+            message.payload,
         )
         self._receive_queue.put_nowait(message)
 
@@ -293,3 +262,38 @@ class Proactor(ServicesInterface, Runnable):
 
     def _send(self, message: Message):
         self.send(message)
+
+
+def str_tasks(loop_: asyncio.AbstractEventLoop, tag: str = "", tasks: Optional[Iterable[Awaitable]] = None) -> str:
+    s = ""
+    try:
+        if tasks is None:
+            tasks = asyncio.all_tasks(loop_)
+        s += f"Tasks: {len(tasks)}  [{tag}]\n"
+
+        def _get_task_exception(task_):
+            try:
+                exception_ = task_.exception()
+            except asyncio.CancelledError as _e:
+                exception_ = _e
+            except asyncio.InvalidStateError:
+                exception_ = None
+            return exception_
+
+        for i, task in enumerate(tasks):
+            s += (
+                f"\t{i + 1}/{len(tasks)}  "
+                f"{task.get_name():20s}  "
+                f"done:{task.done()}   "
+                f"exception:{_get_task_exception(task)}  "
+                f"{task.get_coro()}\n"
+            )
+    except BaseException as e:
+        # noinspection PyBroadException
+        try:
+            s += f"ERROR in str_tasks:\n"
+            s += "".join(traceback.format_exception(e))
+            s += "\n"
+        except:
+            pass
+    return s

--- a/gw_spaceheat/run_atn.py
+++ b/gw_spaceheat/run_atn.py
@@ -9,11 +9,11 @@ from command_line_utils import parse_args, setup_logging
 from config import ScadaSettings, Paths
 
 
-def get_atn(argv: Optional[Sequence[str]] = None, start: bool = True) -> Atn:
+def get_atn(argv: Optional[Sequence[str]] = None, start: bool = True, update_root_logger: bool = False) -> Atn:
     if argv is None:
         argv = sys.argv[1:]
-        if "-l" not in argv and "--log" not in argv:
-            argv.append("-l")
+        if "-v" not in argv and "--verbose" not in argv:
+            argv.append("-v")
     args = parse_args(argv)
     dotenv.load_dotenv(dotenv.find_dotenv(args.env_file))
     settings = ScadaSettings(
@@ -21,10 +21,9 @@ def get_atn(argv: Optional[Sequence[str]] = None, start: bool = True) -> Atn:
             name="atn",
             hardware_layout=Paths().hardware_layout
         ),
-        log_message_summary=True
     )
     settings.paths.mkdirs()
-    setup_logging(args, settings)
+    setup_logging(args, settings, update_root_logger)
     layout = load_house.load_all(settings)
     atn = Atn("a", settings, layout)
     if start:
@@ -32,4 +31,4 @@ def get_atn(argv: Optional[Sequence[str]] = None, start: bool = True) -> Atn:
     return atn
 
 if __name__ == "__main__":
-    get_atn()
+    get_atn(update_root_logger=True)

--- a/gw_spaceheat/run_atn.py
+++ b/gw_spaceheat/run_atn.py
@@ -23,7 +23,7 @@ def get_atn(argv: Optional[Sequence[str]] = None, start: bool = True, update_roo
         ),
     )
     settings.paths.mkdirs()
-    setup_logging(args, settings, update_root_logger)
+    setup_logging(args, settings)
     layout = load_house.load_all(settings)
     atn = Atn("a", settings, layout)
     if start:
@@ -31,4 +31,4 @@ def get_atn(argv: Optional[Sequence[str]] = None, start: bool = True, update_roo
     return atn
 
 if __name__ == "__main__":
-    get_atn(update_root_logger=True)
+    get_atn()

--- a/gw_spaceheat/try_actors.py
+++ b/gw_spaceheat/try_actors.py
@@ -95,7 +95,7 @@ def start_roles(node_alias_list: List, nodes: dict) -> List:
 
 
 def main():
-    args = parse_args(sys.argv[:1])
+    args = parse_args(sys.argv[1:])
     settings = ScadaSettings(_env_file=dotenv.find_dotenv(args.env_file))
     layout = load_house.load_all(settings)
     node_alias_list = []

--- a/test/fragment_runner.py
+++ b/test/fragment_runner.py
@@ -218,7 +218,7 @@ class FragmentRunner:
     def run_fragment(
         cls, fragment_factory: Callable[["FragmentRunner"], ProtocolFragment]
     ):
-        settings = ScadaSettings(log_message_summary=True)
+        settings = ScadaSettings()
         runner = FragmentRunner(settings)
         runner.add_fragment(fragment_factory(runner))
         runner.run()
@@ -313,7 +313,7 @@ class AsyncFragmentRunner(FragmentRunner):
     async def async_run_fragment(
         cls, fragment_factory: Callable[["AsyncFragmentRunner"], ProtocolFragment]
     ):
-        settings = ScadaSettings(log_message_summary=True)
+        settings = ScadaSettings()
         runner = AsyncFragmentRunner(settings)
         runner.add_fragment(fragment_factory(runner))
         await runner.async_run()

--- a/test/show_protocol.py
+++ b/test/show_protocol.py
@@ -1,5 +1,6 @@
 """Sample driver script showing message in/out summary lines for a portion of the mqtt protocol."""
 import enum
+import logging
 import sys
 import argparse
 import time
@@ -13,7 +14,7 @@ from actors.actor_base import ActorBase
 from actors.atn import Atn
 from actors.cloud_ear import CloudEar
 from command_line_utils import add_default_args, setup_logging
-from config import ScadaSettings
+from config import ScadaSettings, LoggingSettings, LoggerLevels
 from data_classes.sh_node import ShNode
 from drivers.power_meter.gridworks_sim_pm1__power_meter_driver import GridworksSimPm1_PowerMeterDriver
 from fragment_runner import ProtocolFragment, FragmentRunner, do_nothing, delimit
@@ -196,7 +197,14 @@ def show_protocol(argv: Optional[List[str]] = None):
             argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         )
     ).parse_args(sys.argv[1:] if argv is None else argv)
-    settings = ScadaSettings(_env_file=dotenv.find_dotenv(args.env_file), log_message_summary=True)
+    settings = ScadaSettings(
+        _env_file=dotenv.find_dotenv(args.env_file),
+        logging=LoggingSettings(
+            levels=LoggerLevels(
+                message_summary=logging.DEBUG
+            )
+        )
+    )
     setup_logging(args, settings)
     please_be_quiet()
     load_house.load_all(settings)

--- a/test/test_actors/test_power_meter.py
+++ b/test/test_actors/test_power_meter.py
@@ -264,7 +264,7 @@ def test_power_meter_small():
 def test_power_meter_periodic_update():
     """Verify the PowerMeter sends its periodic GtShTelemetryFromMultipurposeSensor message (GsPwr sending is
     _not_ tested here."""
-    settings = ScadaSettings(log_message_summary=True, seconds_per_report=1)
+    settings = ScadaSettings(seconds_per_report=1)
     layout = load_house.load_all(settings)
     scada = Scada("a.s", settings=settings, hardware_layout=layout)
     meter_node = layout.node("a.m")
@@ -321,7 +321,7 @@ def test_power_meter_periodic_update():
 def test_power_meter_aggregate_power_forward():
     """Verify that when a simulated change in power is generated, Scadd and Atn both get a GsPwr message"""
 
-    settings = ScadaSettings(log_message_summary=True, seconds_per_report=1)
+    settings = ScadaSettings(seconds_per_report=1)
     layout = load_house.load_all(settings)
     scada = ScadaRecorder("a.s", settings=settings, hardware_layout=layout)
     atn = AtnRecorder("a", settings=settings, hardware_layout=layout)

--- a/test/test_actors2/test_scada2.py
+++ b/test/test_actors2/test_scada2.py
@@ -135,7 +135,7 @@ async def test_scada2_relay_dispatch(tmp_path, monkeypatch):
     logging.basicConfig(level="DEBUG")
     debug_logs_path = tmp_path / "output/debug_logs"
     debug_logs_path.mkdir(parents=True, exist_ok=True)
-    settings = ScadaSettings(seconds_per_report=2, log_message_summary=True)
+    settings = ScadaSettings(seconds_per_report=2)
     layout = load_house.load_all(settings)
     actors = Actors(
         settings,
@@ -295,7 +295,7 @@ async def test_scada2_periodic_status_delivery(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     debug_logs_path = tmp_path / "output/debug_logs"
     debug_logs_path.mkdir(parents=True, exist_ok=True)
-    settings = ScadaSettings(seconds_per_report=2, log_message_summary=True)
+    settings = ScadaSettings(seconds_per_report=2)
     layout = load_house.load_all(settings)
     actors = Actors(
         settings,
@@ -363,7 +363,7 @@ async def test_scada2_status_content_dynamics(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     debug_logs_path = tmp_path / "output/debug_logs"
     debug_logs_path.mkdir(parents=True, exist_ok=True)
-    settings = ScadaSettings(seconds_per_report=2, log_message_summary=True)
+    settings = ScadaSettings(seconds_per_report=2)
     layout = load_house.load_all(settings)
     actors = Actors(
         settings,

--- a/test/test_logging_config.py
+++ b/test/test_logging_config.py
@@ -1,0 +1,211 @@
+import logging
+import time
+
+import pytest
+from pydantic import ValidationError
+
+from logging_config import (
+    DEFAULT_BASE_NAME,
+    DEFAULT_LOG_FILE_NAME,
+    DEFAULT_BYTES_PER_LOG_FILE,
+    DEFAULT_NUM_LOG_FILES,
+    FormatterSettings,
+    LoggerLevels,
+    LoggingSettings,
+    RotatingFileHandlerSettings,
+)
+
+
+def test_logger_levels():
+
+    # Check if fields have been added or renamed
+    assert set(LoggerLevels().__fields__.keys()) == {"general", "message_summary", "lifecycle", "comm_event"}
+
+    # Defaults
+    levels = LoggerLevels()
+    assert levels.general == logging.WARNING
+    assert levels.message_summary == logging.WARNING
+    assert levels.lifecycle == logging.INFO
+    assert levels.comm_event == logging.INFO
+
+    # Set parameters
+    levels = LoggerLevels(
+        general=1,
+        message_summary=2,
+        lifecycle=3,
+        comm_event=4,
+    )
+    assert levels.general == 1
+    assert levels.message_summary == 2
+    assert levels.lifecycle == 3
+    assert levels.comm_event == 4
+
+    # Level conversion
+    with pytest.raises(ValidationError):
+        LoggerLevels(general="FOO")
+
+    levels = LoggerLevels(
+        general="1",
+        message_summary="Critical",
+        lifecycle="DEBUG",
+        comm_event="debug"
+    )
+    assert levels.general == 1
+    assert levels.message_summary == logging.CRITICAL
+    assert levels.lifecycle == logging.DEBUG
+    assert levels.comm_event ==  logging.DEBUG
+
+    # qualified_names()
+    base_name = "foo"
+    assert levels.qualified_logger_names(base_name) == {
+        field_name: f"{base_name}.{field_name}" for
+        field_name in levels.__fields__.keys()
+    }
+
+    # logger_names_to_levels()
+    assert levels.logger_names_to_levels(base_name) == {
+        "foo.general": dict(level=1),
+        "foo.message_summary": dict(level=50),
+        "foo.lifecycle": dict(level=10),
+        "foo.comm_event": dict(level=10),
+    }
+
+    # set_logger_names_to_levels() - all fields set
+    assert levels.set_logger_names_to_levels(base_name) == levels.logger_names_to_levels(base_name)
+    # only some fields set
+    levels = LoggerLevels(general=1, comm_event=2)
+    assert levels.set_logger_names_to_levels(base_name) == {
+        "foo.general": dict(level=1),
+        "foo.comm_event": dict(level=2),
+    }
+    # no fields set
+    assert LoggerLevels().set_logger_names_to_levels(base_name) == {}
+
+def test_logging_settings():
+
+    # Check if loggers have been added or renamed
+    assert set(LoggingSettings().levels.__fields__.keys()) == {"general", "message_summary", "lifecycle", "comm_event"}
+
+    # Defaults
+    logging_settings = LoggingSettings()
+    assert logging_settings.base_log_name == DEFAULT_BASE_NAME
+    assert logging_settings.levels.general == logging.WARNING
+    assert logging_settings.levels.message_summary == logging.WARNING
+    assert logging_settings.levels.lifecycle == logging.INFO
+    assert logging_settings.levels.comm_event == logging.INFO
+
+    # constructor settings
+    logging_settings = LoggingSettings(
+        base_log_name="foo",
+        levels=LoggerLevels(
+            general=1,
+            message_summary=2,
+            lifecycle=3,
+            comm_event=4,
+        )
+    )
+    assert logging_settings.base_log_name == "foo"
+    assert logging_settings.levels.general == 1
+    assert logging_settings.levels.message_summary == 2
+    assert logging_settings.levels.lifecycle == 3
+    assert logging_settings.levels.comm_event == 4
+
+    # qualified_names()
+    logging_settings = LoggingSettings()
+    assert logging_settings.qualified_logger_names() == {
+        field_name: f"gridworks.{field_name}" for
+        field_name in logging_settings.levels.__fields__.keys()
+    }
+
+    # logger_levels()
+    assert logging_settings.logger_levels() == {
+        "gridworks.general": dict(level=30),
+        "gridworks.message_summary": dict(level=30),
+        "gridworks.lifecycle": dict(level=20),
+        "gridworks.comm_event": dict(level=20),
+    }
+
+    # set_logger_levels() - no fields set
+    assert logging_settings.set_logger_levels() == {}
+
+    # some fields set
+    logging_settings = LoggingSettings(levels=LoggerLevels(general=1, lifecycle=2))
+    assert logging_settings.set_logger_levels() == {
+        "gridworks.general": dict(level=1),
+        "gridworks.lifecycle": dict(level=2),
+    }
+
+    # custom base name and level dicts
+    logging_settings = LoggingSettings(base_log_name="foo", levels=LoggerLevels(general=1))
+    assert logging_settings.qualified_logger_names() == {
+        "general": "foo.general",
+        "message_summary": "foo.message_summary",
+        "lifecycle": "foo.lifecycle",
+        "comm_event": "foo.comm_event",
+    }
+    assert logging_settings.logger_levels() == {
+        "foo.general": dict(level=1),
+        "foo.message_summary": dict(level=30),
+        "foo.lifecycle": dict(level=20),
+        "foo.comm_event": dict(level=20),
+    }
+    assert logging_settings.set_logger_levels() == {"foo.general": dict(level=1)}
+
+    # verbose()
+    logging_settings = LoggingSettings()
+    assert not logging_settings.verbose()
+    logging_settings.levels.general = logging.INFO
+    assert logging_settings.verbose()
+
+    # message_summary_enabled()
+    assert not logging_settings.message_summary_enabled()
+    logging_settings.levels.message_summary = 20
+    assert logging_settings.message_summary_enabled()
+
+def get_exp_formatted_time(record: logging.LogRecord, formatter: logging.Formatter) -> str:
+    return formatter.default_msec_format % (
+        time.strftime(
+            formatter.default_time_format,
+            time.gmtime(record.created)
+        ),
+        record.msecs,
+    )
+
+def test_formatter_settings():
+    settings = FormatterSettings()
+    formatter = settings.create()
+    record = logging.makeLogRecord(
+        dict(
+            msg="bla %s %d",
+            args=("biz", 1)
+        )
+    )
+    got_formatted_time = formatter.formatTime(record, formatter.datefmt)
+    created_gmt = time.gmtime(record.created)
+    strftimed = time.strftime(logging.Formatter.default_time_format, created_gmt)
+    assert got_formatted_time.startswith(strftimed)
+    exp_formatted_time = get_exp_formatted_time(record, formatter)
+    assert got_formatted_time == exp_formatted_time
+    formatted = formatter.format(record)
+    assert formatted.startswith(exp_formatted_time)
+    assert formatted.endswith(record.msg % record.args)
+
+def test_rotating_file_handler_settings(tmp_path):
+    settings = RotatingFileHandlerSettings()
+    handler = settings.create(tmp_path, FormatterSettings().create())
+    assert handler.level == logging.NOTSET
+    assert handler.maxBytes == DEFAULT_BYTES_PER_LOG_FILE
+    assert handler.backupCount == DEFAULT_NUM_LOG_FILES - 1
+    assert handler.stream.name == str(tmp_path / DEFAULT_LOG_FILE_NAME)
+    bytes_per_log_file = 10
+    num_log_files = 3
+    settings = RotatingFileHandlerSettings(
+        level=logging.INFO,
+        bytes_per_log_file=bytes_per_log_file,
+        num_log_files=num_log_files
+    )
+    handler = settings.create(tmp_path, FormatterSettings().create())
+    assert handler.level == logging.INFO
+    assert handler.maxBytes == bytes_per_log_file
+    assert handler.backupCount == num_log_files - 1
+    assert handler.stream.name == str(tmp_path / DEFAULT_LOG_FILE_NAME)

--- a/test/test_logging_setup.py
+++ b/test/test_logging_setup.py
@@ -16,7 +16,6 @@ def test_get_default_logging_config(caplog, capsys):
         logging=LoggingSettings(
             levels=LoggerLevels(
                 general=logging.INFO,
-                message_summary=logging.INFO,
             )
         )
     )
@@ -24,7 +23,7 @@ def test_get_default_logging_config(caplog, capsys):
     pytest_root_handlers = len(root.handlers)
     errors = []
 
-    setup_logging(argparse.Namespace(), settings, errors=errors)
+    setup_logging(argparse.Namespace(message_summary=True), settings, errors=errors)
     assert len(errors) == 0
 
     # root logger changes

--- a/test/test_logging_setup.py
+++ b/test/test_logging_setup.py
@@ -4,7 +4,7 @@ import logging.handlers
 from typing import Optional
 
 from config import Paths, ScadaSettings
-from logging_config import LoggingSettings, LoggerLevels
+from logging_config import LoggingSettings, LoggerLevels, DEFAULT_LOG_FILE_NAME
 from logging_setup import setup_logging
 from test.test_logging_config import get_exp_formatted_time
 
@@ -66,4 +66,10 @@ def test_get_default_logging_config(caplog, capsys):
         assert capsys.readouterr().err == exp_msg
         text += exp_msg
         caplog.clear()
+
+    # Check file contents
+    log_path = settings.paths.log_dir / DEFAULT_LOG_FILE_NAME
+    with log_path.open() as f:
+        log_contents = f.read()
+    assert log_contents == text
 

--- a/test/test_logging_setup.py
+++ b/test/test_logging_setup.py
@@ -1,0 +1,69 @@
+import argparse
+import logging
+import logging.handlers
+from typing import Optional
+
+from config import Paths, ScadaSettings
+from logging_config import LoggingSettings, LoggerLevels
+from logging_setup import setup_logging
+from test.test_logging_config import get_exp_formatted_time
+
+
+def test_get_default_logging_config(caplog, capsys):
+    paths = Paths()
+    paths.mkdirs()
+    settings = ScadaSettings(
+        logging=LoggingSettings(
+            levels=LoggerLevels(
+                general=logging.INFO,
+                message_summary=logging.INFO,
+            )
+        )
+    )
+    root = logging.getLogger()
+    pytest_root_handlers = len(root.handlers)
+    errors = []
+
+    setup_logging(argparse.Namespace(), settings, errors=errors)
+    assert len(errors) == 0
+
+    # root logger changes
+    assert root.level == logging.INFO
+    assert len(root.handlers) == pytest_root_handlers + 2
+    stream_handler: Optional[logging.StreamHandler] = None
+    file_handler: Optional[logging.handlers.RotatingFileHandler] = None
+    for i in range(-1, -3, -1):
+        handler = root.handlers[i]
+        if isinstance(handler, logging.StreamHandler):
+            stream_handler = handler
+        if isinstance(handler, logging.handlers.RotatingFileHandler):
+            file_handler = handler
+    assert stream_handler is not None
+    assert file_handler is not None
+    assert root.level == settings.logging.base_log_level
+    # Sub-logger levels
+    logger_names = settings.logging.qualified_logger_names()
+
+    # Check if loggers have been added or renamed
+    assert set(LoggingSettings().levels.__fields__.keys()) == {"general", "message_summary", "lifecycle", "comm_event"}
+    for field_name in settings.logging.levels.__fields__:
+        logger_level = logging.getLogger(logger_names[field_name]).level
+        settings_level = getattr(settings.logging.levels, field_name)
+        assert logger_level == settings_level
+    assert len(caplog.records) == 0
+
+    # Check logger filter by level and message formatting.
+    formatter = settings.logging.formatter.create()
+    text = ""
+    for i, logger_name in enumerate(["root"] + list(logger_names.values())):
+        logger = logging.getLogger(logger_name)
+        msg = "%d: %s"
+        logger.debug(msg, i, logger.name)
+        assert len(caplog.records) == 0
+        logger.info(msg, i, logger.name)
+        assert len(caplog.records) == 1
+        exp_msg = "%s %s\n" % (get_exp_formatted_time(caplog.records[-1], formatter), msg % (i, logger.name))
+        assert capsys.readouterr().err == exp_msg
+        text += exp_msg
+        caplog.clear()
+

--- a/test/test_message_exchange.py
+++ b/test/test_message_exchange.py
@@ -19,7 +19,7 @@ def test_message_exchange(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     debug_logs_path = tmp_path / "output/debug_logs"
     debug_logs_path.mkdir(parents=True, exist_ok=True)
-    settings = ScadaSettings(log_message_summary=True)
+    settings = ScadaSettings()
     layout = load_house.load_all(settings)
     scada = ScadaRecorder("a.s", settings=settings, hardware_layout=layout)
     atn = AtnRecorder("a", settings=settings, hardware_layout=layout)

--- a/test/test_proactor_logger.py
+++ b/test/test_proactor_logger.py
@@ -1,0 +1,48 @@
+import argparse
+import logging
+
+from config import Paths, ScadaSettings
+from logging_setup import setup_logging
+from proactor import ProactorLogger
+from test.conftest import LoggerGuards
+
+
+def test_proactor_logger(caplog):
+    paths = Paths()
+    paths.mkdirs()
+    settings = ScadaSettings()
+    with LoggerGuards():
+        errors = []
+        setup_logging(argparse.Namespace(), settings, errors=errors)
+        assert len(errors) == 0
+        logger = ProactorLogger(**settings.logging.qualified_logger_names())
+        assert not logger.general_enabled
+        assert not logger.message_summary_enabled
+        assert logger.message_summary_logger.level == logging.WARNING
+        assert not logger.path_enabled
+        logger.message_summary("", "", "")
+        assert len(caplog.records) == 0
+        logger.path("foo")
+        assert len(caplog.records) == 0
+        assert logger.lifecycle_enabled
+        assert logger.comm_event_enabled
+
+    errors = []
+    setup_logging(argparse.Namespace(verbose=True), settings, errors=errors)
+    assert len(errors) == 0
+    logger = ProactorLogger(**settings.logging.qualified_logger_names())
+    assert logger.general_enabled
+    assert logger.message_summary_enabled
+    assert logger.message_summary_logger.level == logging.DEBUG
+    assert logger.path_enabled
+    assert logger.lifecycle_enabled
+    assert logger.comm_event_enabled
+    logger.info("info")
+    assert len(caplog.records) == 1
+    caplog.clear()
+    for function_name in ["general", "path", "lifecycle", "comm_event"]:
+        getattr(logger, function_name)(function_name)
+        assert len(caplog.records) == 1
+        caplog.clear()
+    logger.message_summary("IN", "x", "y")
+    assert len(caplog.records) == 1

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -28,6 +28,7 @@ def test_run_nodes_main(aliases):
         run_nodes_main(
             argv=["-n", *aliases],
             dbg=dbg,
+            update_root_logger=False,
         )
         assert len(dbg["actors"]) == len(aliases)
     finally:
@@ -79,7 +80,7 @@ async def test_run_local2(tmp_path, monkeypatch):
                     print(f"  {node.alias:42}  {node.role.value:30}  {node.actor_class}")
                     if node.role != Role.SCADA:
                         node.reporting_sample_period_s = 1
-            script_task = asyncio.create_task(run_async_actors_main(argv=argv))
+            script_task = asyncio.create_task(run_async_actors_main(argv=argv, update_root_logger=False))
             try:
                 # Verify Atn got status and snapshot
                 await await_for(

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -28,7 +28,6 @@ def test_run_nodes_main(aliases):
         run_nodes_main(
             argv=["-n", *aliases],
             dbg=dbg,
-            update_root_logger=False,
         )
         assert len(dbg["actors"]) == len(aliases)
     finally:
@@ -80,7 +79,7 @@ async def test_run_local2(tmp_path, monkeypatch):
                     print(f"  {node.alias:42}  {node.role.value:30}  {node.actor_class}")
                     if node.role != Role.SCADA:
                         node.reporting_sample_period_s = 1
-            script_task = asyncio.create_task(run_async_actors_main(argv=argv, update_root_logger=False))
+            script_task = asyncio.create_task(run_async_actors_main(argv=argv))
             try:
                 # Verify Atn got status and snapshot
                 await await_for(


### PR DESCRIPTION
Articulates an approach to logging: 

* Standard python `logging` module is used in place of print()
* Log files in `$HOME/.local/state/gridworks/scada/scada.log`. 
* 20 MB in 10 files is stored by default. 
* A [LoggingSettings](https://github.com/thegridelectric/gw-scada-spaceheat-python/blob/as/logging/gw_spaceheat/logging_config.py#L85) object inside ScadaSettings allows some customization.
* relevant command line arguments are -v/--verbose and --message-summary.
* proactor and scada code use a [ProactorLogger](https://github.com/thegridelectric/gw-scada-spaceheat-python/blob/as/logging/gw_spaceheat/proactor/logger.py#L66) object which wraps standard the standard python loggers we have configured in a convenient way.


Intended usage:
	
* starting a script: 
	
	```
	python gw_spaceheat/run_scada.py -v
	```

* Logging [setup](https://github.com/thegridelectric/gw-scada-spaceheat-python/blob/main/gw_spaceheat/command_line_utils.py#L100) at the beginning of a script: 
	
	```
	args = parse_args(argv, default_nodes=default_nodes)
	settings = ScadaSettings(_env_file=dotenv.find_dotenv(args.env_file))
    settings.paths.mkdirs()
    setup_logging(args, settings)
	```

* In [message processing](https://github.com/thegridelectric/gw-scada-spaceheat-python/blob/main/gw_spaceheat/proactor/proactor_implementation.py#L147): 

	```
    async def process_message(self, message: Message):
        self._logger.path("++Proactor.process_message %s/%s", message.header.src, message.header.message_type)
        path_dbg = 0
        self._logger.message_summary(
            "INx ",
            self.name,
            f"{message.header.src}/{message.header.message_type}",
            message.payload,
        )
        if message.header.message_type == MessageType.mqtt_message.value:
            path_dbg |= 0x00000001
            await self._process_mqtt_message(message)
        ...
        self._logger.path("--Proactor.process_message  path:0x%08X", path_dbg)

	```

Some notable caveats and observations: 
* The default format is now `2022-09-22 20:38:35.617 message`. 
* print() should not be used. Instead use a python logging library logger. the `_logger` member of Scada2 and Proactor provides access to several loggers. 
* The string construction style is printf-style/'%' based, e.g.: 
	
	```
	self._loggers.info("foo %s, %d 0x%08X", "bar", 1, 16)
	```
* any logger can be accessed with `logging.getLogger("logger.name")`
* Our logger names are currently: 
	
	```
	gridworks.general
	gridworks.message_summary
	gridworks.lifecycle
	gridworks.comm_event
	```

* screen_print() in the old code has not been updated. I'm hoping we can replace the old code with new code that can feed sensors over mqtt on remote machines without too much trouble. 

