### PR TITLE
Don't set logging level root logger

### DIFF
--- a/gw_spaceheat/logging_config.py
+++ b/gw_spaceheat/logging_config.py
@@ -48,7 +48,6 @@ class RotatingFileHandlerSettings(BaseModel):
 
 
 class LoggerLevels(BaseModel):
-    general: int | str = logging.WARNING
     message_summary: int | str = logging.WARNING
     lifecycle: int | str = logging.INFO
     comm_event: int | str = logging.INFO
@@ -86,22 +85,26 @@ class LoggerLevels(BaseModel):
 
 class LoggingSettings(BaseModel):
     base_log_name: str = DEFAULT_BASE_NAME
-    base_log_level: int = logging.INFO
+    base_log_level: int = logging.WARNING
     levels: LoggerLevels = LoggerLevels()
     formatter: FormatterSettings = FormatterSettings()
     file_handler: RotatingFileHandlerSettings = RotatingFileHandlerSettings()
 
     def qualified_logger_names(self) -> dict[str, str]:
-        return self.levels.qualified_logger_names(self.base_log_name)
+        return dict(self.levels.qualified_logger_names(self.base_log_name), base=self.base_log_name)
 
     def logger_levels(self) -> dict[str, dict[str, int]]:
-        return self.levels.logger_names_to_levels(self.base_log_name)
+        d = dict(
+            self.levels.logger_names_to_levels(self.base_log_name),
+        )
+        d[self.base_log_name] = dict(level=self.base_log_level)
+        return d
 
     def set_logger_levels(self) -> dict[str, dict[str, int]]:
         return self.levels.set_logger_names_to_levels(self.base_log_name)
 
     def verbose(self) -> bool:
-        return self.levels.general <= logging.INFO
+        return self.base_log_level <= logging.INFO
 
     def message_summary_enabled(self) -> bool:
         return self.levels.message_summary <= logging.INFO

--- a/gw_spaceheat/logging_setup.py
+++ b/gw_spaceheat/logging_setup.py
@@ -53,7 +53,7 @@ def setup_logging(
         # Take any arguments from command line
         try:
             if getattr(args, "verbose", None):
-                settings.logging.levels.general = logging.INFO
+                settings.logging.base_log_level = logging.INFO
                 settings.logging.levels.message_summary = logging.DEBUG
             if getattr(args, "message_summary", None):
                 settings.logging.levels.message_summary = logging.INFO
@@ -82,7 +82,6 @@ def setup_logging(
             errors.append(e)
 
         # Set application logger levels
-        logging.getLogger(settings.logging.base_log_name).setLevel(logging.INFO)
         for logger_name, logger_settings in settings.logging.logger_levels().items():
             try:
                 logger = logging.getLogger(logger_name)

--- a/gw_spaceheat/logging_setup.py
+++ b/gw_spaceheat/logging_setup.py
@@ -82,6 +82,7 @@ def setup_logging(
             errors.append(e)
 
         # Set application logger levels
+        logging.getLogger(settings.logging.base_log_name).setLevel(logging.INFO)
         for logger_name, logger_settings in settings.logging.logger_levels().items():
             try:
                 logger = logging.getLogger(logger_name)
@@ -89,9 +90,8 @@ def setup_logging(
             except BaseException as e:
                 errors.append(e)
 
-        # Turn on logging in root logger, with level and handlers, as requested
+        # Assign handlers to root logger
         root_logger = logging.getLogger()
-        root_logger.setLevel(logging.INFO)
         for handler in [screen_handler, file_handler]:
             if handler is not None:
                 try:

--- a/gw_spaceheat/proactor/logger.py
+++ b/gw_spaceheat/proactor/logger.py
@@ -70,8 +70,8 @@ class ProactorLogger(logging.LoggerAdapter):
     lifecycle_logger: logging.Logger
     comm_event_logger: logging.Logger
 
-    def __init__(self, general: str, message_summary: str, lifecycle: str, comm_event: str, extra: Optional[dict] = None):
-        super().__init__(logging.getLogger(general), extra=extra)
+    def __init__(self, base: str, message_summary: str, lifecycle: str, comm_event: str, extra: Optional[dict] = None):
+        super().__init__(logging.getLogger(base), extra=extra)
         self.message_summary_logger = logging.getLogger(message_summary)
         self.lifecycle_logger = logging.getLogger(lifecycle)
         self.comm_event_logger = logging.getLogger(comm_event)
@@ -125,13 +125,6 @@ class ProactorLogger(logging.LoggerAdapter):
 
     def comm_event(self, msg: str, *args, **kwargs) -> None:
         self.comm_event_logger.info(msg, *args, **kwargs)
-
-    def general(self, msg: str, *args, **kwargs) -> None:
-        self.info(msg, *args, **kwargs)
-
-    @property
-    def general_logger(self) -> logging.Logger:
-        return self.logger
 
     def __repr__(self):
         return (

--- a/test/test_logging_config.py
+++ b/test/test_logging_config.py
@@ -133,7 +133,7 @@ def test_logging_settings():
     # custom base name and level dicts
     logging_settings = LoggingSettings(base_log_name="foo", base_log_level=0, levels=LoggerLevels(message_summary=1))
     assert logging_settings.qualified_logger_names() == {
-        "base":"foo",
+        "base": "foo",
         "message_summary": "foo.message_summary",
         "lifecycle": "foo.lifecycle",
         "comm_event": "foo.comm_event",

--- a/test/test_logging_setup.py
+++ b/test/test_logging_setup.py
@@ -20,6 +20,7 @@ def test_get_default_logging_config(caplog, capsys):
         )
     )
     root = logging.getLogger()
+    old_root_level = root.getEffectiveLevel()
     pytest_root_handlers = len(root.handlers)
     errors = []
 
@@ -27,7 +28,7 @@ def test_get_default_logging_config(caplog, capsys):
     assert len(errors) == 0
 
     # root logger changes
-    assert root.level == logging.INFO
+    assert root.getEffectiveLevel() == old_root_level
     assert len(root.handlers) == pytest_root_handlers + 2
     stream_handler: Optional[logging.StreamHandler] = None
     file_handler: Optional[logging.handlers.RotatingFileHandler] = None
@@ -39,7 +40,7 @@ def test_get_default_logging_config(caplog, capsys):
             file_handler = handler
     assert stream_handler is not None
     assert file_handler is not None
-    assert root.level == settings.logging.base_log_level
+    assert logging.getLogger("gridworks").getEffectiveLevel() == settings.logging.base_log_level
     # Sub-logger levels
     logger_names = settings.logging.qualified_logger_names()
 
@@ -54,7 +55,7 @@ def test_get_default_logging_config(caplog, capsys):
     # Check logger filter by level and message formatting.
     formatter = settings.logging.formatter.create()
     text = ""
-    for i, logger_name in enumerate(["root"] + list(logger_names.values())):
+    for i, logger_name in enumerate([settings.logging.base_log_name] + list(logger_names.values())):
         logger = logging.getLogger(logger_name)
         msg = "%d: %s"
         logger.debug(msg, i, logger.name)

--- a/test/test_logging_setup.py
+++ b/test/test_logging_setup.py
@@ -12,13 +12,7 @@ from test.test_logging_config import get_exp_formatted_time
 def test_get_default_logging_config(caplog, capsys):
     paths = Paths()
     paths.mkdirs()
-    settings = ScadaSettings(
-        logging=LoggingSettings(
-            levels=LoggerLevels(
-                general=logging.INFO,
-            )
-        )
-    )
+    settings = ScadaSettings(logging=LoggingSettings(base_log_level=logging.INFO))
     root = logging.getLogger()
     old_root_level = root.getEffectiveLevel()
     pytest_root_handlers = len(root.handlers)
@@ -45,11 +39,13 @@ def test_get_default_logging_config(caplog, capsys):
     logger_names = settings.logging.qualified_logger_names()
 
     # Check if loggers have been added or renamed
-    assert set(LoggingSettings().levels.__fields__.keys()) == {"general", "message_summary", "lifecycle", "comm_event"}
+    assert set(LoggingSettings().levels.__fields__.keys()) == {"message_summary", "lifecycle", "comm_event"}
     for field_name in settings.logging.levels.__fields__:
         logger_level = logging.getLogger(logger_names[field_name]).level
         settings_level = getattr(settings.logging.levels, field_name)
         assert logger_level == settings_level
+    assert logging.getLogger(logger_names["base"]).level == settings.logging.base_log_level
+
     assert len(caplog.records) == 0
 
     # Check logger filter by level and message formatting.

--- a/test/test_proactor_logger.py
+++ b/test/test_proactor_logger.py
@@ -16,7 +16,7 @@ def test_proactor_logger(caplog):
         setup_logging(argparse.Namespace(), settings, errors=errors)
         assert len(errors) == 0
         logger = ProactorLogger(**settings.logging.qualified_logger_names())
-        assert not logger.general_enabled
+        assert not logger.isEnabledFor(logging.INFO)
         assert not logger.message_summary_enabled
         assert logger.message_summary_logger.level == logging.WARNING
         assert not logger.path_enabled
@@ -31,7 +31,7 @@ def test_proactor_logger(caplog):
     setup_logging(argparse.Namespace(verbose=True), settings, errors=errors)
     assert len(errors) == 0
     logger = ProactorLogger(**settings.logging.qualified_logger_names())
-    assert logger.general_enabled
+    assert logger.isEnabledFor(logging.INFO)
     assert logger.message_summary_enabled
     assert logger.message_summary_logger.level == logging.DEBUG
     assert logger.path_enabled
@@ -40,7 +40,7 @@ def test_proactor_logger(caplog):
     logger.info("info")
     assert len(caplog.records) == 1
     caplog.clear()
-    for function_name in ["general", "path", "lifecycle", "comm_event"]:
+    for function_name in ["path", "lifecycle", "comm_event"]:
         getattr(logger, function_name)(function_name)
         assert len(caplog.records) == 1
         caplog.clear()


### PR DESCRIPTION
Base logging level now set on "gridworks" logger; this is so that we don't accidentally turn on output of 3rd party loggers. "gridworks.general" logger replaced with "gridworks" logger. 