### PR TITLE
Remove race condition in tracking 'fully subscribed'

### DIFF
--- a/gw_spaceheat/proactor/link_state.py
+++ b/gw_spaceheat/proactor/link_state.py
@@ -379,8 +379,8 @@ class LinkStates:
     def process_mqtt_connect_fail(self, message: Message[MQTTConnectFailPayload]) -> Result[Transition, InvalidCommStateInput]:
         return self[message.Payload.client_name].process_mqtt_connect_fail()
 
-    def process_mqtt_suback(self, message: Message[MQTTSubackPayload]) -> Result[Transition, InvalidCommStateInput]:
-        return self[message.Payload.client_name].process_mqtt_suback(message.Payload.num_pending_subscriptions)
+    def process_mqtt_suback(self, name: str, num_pending_subscriptions: int) -> Result[Transition, InvalidCommStateInput]:
+        return self[name].process_mqtt_suback(num_pending_subscriptions)
 
     def process_mqtt_message(self, message: Message[MQTTReceiptPayload]) -> Result[Transition, InvalidCommStateInput]:
         return self[message.Payload.client_name].process_mqtt_message()

--- a/gw_spaceheat/proactor/message.py
+++ b/gw_spaceheat/proactor/message.py
@@ -94,7 +94,6 @@ class MQTTReceiptMessage(MQTTClientMessage[MQTTReceiptPayload]):
 class MQTTSubackPayload(MQTTClientsPayload):
     mid: int
     granted_qos: List[int]
-    num_pending_subscriptions: int
 
 
 class MQTTSubackMessage(MQTTClientMessage[MQTTSubackPayload]):
@@ -104,7 +103,6 @@ class MQTTSubackMessage(MQTTClientMessage[MQTTSubackPayload]):
         userdata: Optional[Any],
         mid: int,
         granted_qos: List[int],
-        num_pending_subscriptions: int,
     ):
         super().__init__(
             message_type=MessageType.mqtt_suback,
@@ -113,7 +111,6 @@ class MQTTSubackMessage(MQTTClientMessage[MQTTSubackPayload]):
                 userdata=userdata,
                 mid=mid,
                 granted_qos=granted_qos,
-                num_pending_subscriptions=num_pending_subscriptions,
             ),
         )
 

--- a/gw_spaceheat/proactor/mqtt.py
+++ b/gw_spaceheat/proactor/mqtt.py
@@ -134,7 +134,6 @@ class MQTTClientWrapper:
                 self._pending_subscriptions.remove(topic)
         return len(self._pending_subscriptions)
 
-
     def on_subscribe(self, _, userdata, mid, granted_qos):
         self._receive_queue.put(
             MQTTSubackMessage(
@@ -243,5 +242,5 @@ class MQTTClients:
         for client_name in self._clients:
             self._clients[client_name].disable_logger()
 
-    def client_wrapper(self, client:str) -> MQTTClientWrapper:
+    def client_wrapper(self, client: str) -> MQTTClientWrapper:
         return self._clients[client]

--- a/gw_spaceheat/proactor/mqtt.py
+++ b/gw_spaceheat/proactor/mqtt.py
@@ -9,6 +9,7 @@ Main current limitation: each interaction between asyncio code and the mqtt clie
 import asyncio
 import logging
 import uuid
+from typing import cast
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -26,6 +27,7 @@ from proactor.message import MQTTConnectMessage
 from proactor.message import MQTTDisconnectMessage
 from proactor.message import MQTTReceiptMessage
 from proactor.message import MQTTSubackMessage
+from proactor.message import MQTTSubackPayload
 from proactor.sync_thread import AsyncQueueWriter
 
 
@@ -76,6 +78,7 @@ class MQTTClientWrapper:
         self._subscriptions[topic] = qos
         self._pending_subscriptions.add(topic)
         subscribe_result = self._client.subscribe(topic, qos)
+        print(f"subscribe_result: {subscribe_result}")
         if subscribe_result[0] == MQTT_ERR_SUCCESS:
             self._pending_subacks[subscribe_result[1]] = [topic]
         return subscribe_result
@@ -112,6 +115,9 @@ class MQTTClientWrapper:
             not self.num_subscriptions() or not self.num_pending_subscriptions()
         )
 
+    def subscription_items(self) -> list[Tuple[str, int]]:
+        return list(cast(list[Tuple[str, int]], self._subscriptions.items()))
+
     def on_message(self, _, userdata, message):
         self._receive_queue.put(
             MQTTReceiptMessage(
@@ -121,20 +127,23 @@ class MQTTClientWrapper:
             )
         )
 
-    def on_subscribe(self, _, userdata, mid, granted_qos):
-        topics = self._pending_subacks.pop(mid, [])
+    def handle_suback(self, suback: MQTTSubackPayload) -> int:
+        topics = self._pending_subacks.pop(suback.mid, [])
         if topics:
             for topic in topics:
                 self._pending_subscriptions.remove(topic)
-            self._receive_queue.put(
-                MQTTSubackMessage(
-                    client_name=self.name,
-                    userdata=userdata,
-                    mid=mid,
-                    granted_qos=granted_qos,
-                    num_pending_subscriptions=len(self._pending_subscriptions),
-                )
+        return len(self._pending_subscriptions)
+
+
+    def on_subscribe(self, _, userdata, mid, granted_qos):
+        self._receive_queue.put(
+            MQTTSubackMessage(
+                client_name=self.name,
+                userdata=userdata,
+                mid=mid,
+                granted_qos=granted_qos,
             )
+        )
 
     def on_connect(self, _, userdata, flags, rc):
         self._receive_queue.put(
@@ -202,6 +211,9 @@ class MQTTClients:
     def unsubscribe(self, client: str, topic: str) -> Tuple[int, Optional[int]]:
         return self._clients[client].unsubscribe(topic)
 
+    def handle_suback(self, suback: MQTTSubackPayload) -> int:
+        return self._clients[suback.client_name].handle_suback(suback)
+
     def stop(self):
         for client in self._clients.values():
             client.stop()
@@ -230,3 +242,6 @@ class MQTTClients:
     def disable_loggers(self):
         for client_name in self._clients:
             self._clients[client_name].disable_logger()
+
+    def client_wrapper(self, client:str) -> MQTTClientWrapper:
+        return self._clients[client]

--- a/tests/test_proactor/test_link_state.py
+++ b/tests/test_proactor/test_link_state.py
@@ -16,7 +16,6 @@ from proactor.message import MQTTConnectFailMessage
 from proactor.message import MQTTConnectMessage
 from proactor.message import MQTTDisconnectMessage
 from proactor.message import MQTTReceiptMessage
-from proactor.message import MQTTSubackMessage
 
 
 def assert_transition(got: Transition, exp: Transition):
@@ -55,7 +54,7 @@ class _Case:
                 case TransitionName.mqtt_suback:
                     if content is None:
                         content = 1
-                    content = MQTTSubackMessage(client_name=name, userdata=None, mid=1, granted_qos=[1], num_pending_subscriptions=content)
+                    content = name, content
                 case TransitionName.message_from_peer:
                     content = MQTTReceiptMessage(client_name=name, userdata=None, message=MQTTMessage())
                 case _:
@@ -92,7 +91,7 @@ class _Case:
             case TransitionName.mqtt_disconnected:
                 self.assert_case(links, name, links.process_mqtt_disconnected(self.get_input_content(name)))
             case TransitionName.mqtt_suback:
-                self.assert_case(links, name, links.process_mqtt_suback(self.get_input_content(name)))
+                self.assert_case(links, name, links.process_mqtt_suback(*self.get_input_content(name)))
             case TransitionName.message_from_peer:
                 self.assert_case(links, name, links.process_mqtt_message(self.get_input_content(name)))
             case TransitionName.response_timeout:

--- a/tests/utils/scada2_recorder.py
+++ b/tests/utils/scada2_recorder.py
@@ -1,4 +1,3 @@
-import functools
 from collections import defaultdict
 from dataclasses import dataclass
 from dataclasses import field
@@ -6,19 +5,21 @@ from typing import Any
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import Tuple
 
 from gwproto import Message
 from gwproto.messages import CommEvent
 from gwproto.messages import EventT
 from gwproto.messages import PingMessage
+from paho.mqtt.client import MQTT_ERR_SUCCESS
 
 from actors2 import Scada2
 from config import ScadaSettings
 from data_classes.hardware_layout import HardwareLayout
 from data_classes.sh_node import ShNode
 from proactor.message import MQTTReceiptPayload
-from proactor.message import MQTTSubackMessage
 from proactor.message import MQTTSubackPayload
+from proactor.mqtt import MQTTClientWrapper
 
 
 @dataclass
@@ -80,21 +81,10 @@ class Stats:
         return s
 
 
-# noinspection PyProtectedMember
-def split_suback(_, userdata, mid, granted_qos, paho_client_wrapper):
-    topics = paho_client_wrapper._pending_subacks.pop(mid, [])
-    if topics:
-        for topic in topics:
-            paho_client_wrapper._pending_subscriptions.remove(topic)
-            paho_client_wrapper._receive_queue.put(
-                MQTTSubackMessage(
-                    client_name=paho_client_wrapper.name,
-                    userdata=userdata,
-                    mid=mid,
-                    granted_qos=granted_qos,
-                    num_pending_subscriptions=len(paho_client_wrapper._pending_subscriptions),
-                )
-            )
+def split_subscriptions(client_wrapper: MQTTClientWrapper) -> Tuple[int, Optional[int]]:
+    for i, (topic, qos) in enumerate(client_wrapper.subscription_items()):
+        MQTTClientWrapper.subscribe(client_wrapper, topic, qos)
+    return MQTT_ERR_SUCCESS, None
 
 
 class Scada2Recorder(Scada2):
@@ -123,18 +113,15 @@ class Scada2Recorder(Scada2):
             link_stats.comm_events.append(event)
         super().generate_event(event)
 
-    # noinspection PyProtectedMember
     def split_client_subacks(self, client_name: str):
-        paho_client_wrapper = self._mqtt_clients._clients[client_name]
-        # that's a lot of clients. Here's another.
-        paho_client = paho_client_wrapper._client
-        paho_client.on_subscribe = functools.partial(split_suback, paho_client_wrapper=paho_client_wrapper)
+        client_wrapper = self._mqtt_clients.client_wrapper(client_name)
+        def member_split_subscriptions():
+            return split_subscriptions(client_wrapper)
+        client_wrapper.subscribe_all = member_split_subscriptions
 
-    # noinspection PyProtectedMember
     def restore_client_subacks(self, client_name: str):
-        paho_client_wrapper = self._mqtt_clients._clients[client_name]
-        paho_client = paho_client_wrapper._client
-        paho_client.on_subscribe = paho_client_wrapper.on_subscribe
+        client_wrapper = self._mqtt_clients.client_wrapper(client_name)
+        client_wrapper.subscribe_all = MQTTClientWrapper.subscribe_all
 
     def pause_subacks(self):
         self.subacks_paused = True

--- a/tests/utils/scada2_recorder.py
+++ b/tests/utils/scada2_recorder.py
@@ -115,6 +115,7 @@ class Scada2Recorder(Scada2):
 
     def split_client_subacks(self, client_name: str):
         client_wrapper = self._mqtt_clients.client_wrapper(client_name)
+
         def member_split_subscriptions():
             return split_subscriptions(client_wrapper)
         client_wrapper.subscribe_all = member_split_subscriptions


### PR DESCRIPTION
The data structures tracking whether all subscriptions had been acked was modified in two threads without locking and, unsurprisingly, a race condition sometimes caused failure to resolve comm state. We saw this failure in CI often enough to be aggravated. These data structures are now only modified in the main message processing thread. 

The most commonly observed symptom was that FragmentRunner.await_connect() would fail and message such as "waiting for gridworks connect" would be present. The specific observed cause was that response to the subscription message (and therefore the call to on_subscribe(mid)) arrived before the paho client subscribe() call had even returned so the data structure contain the sent message id was still empty in on_subscribe(mid) and the suback was therefore ignored.

