### PR TITLE
local dev rabbit broker for scada.gridworks_mqtt

### DIFF
--- a/arm.sh
+++ b/arm.sh
@@ -1,0 +1,2 @@
+docker-compose -f docker-arm.yml down
+docker-compose -f docker-arm.yml up -d

--- a/docker-arm.yml
+++ b/docker-arm.yml
@@ -1,0 +1,26 @@
+version: "3.5"
+
+networks:
+  dev:
+
+services:
+  rabbit:
+    container_name: gnf-rabbit
+    hostname: rabbit
+    networks:
+      - "dev"
+    image: "jessmillar/dev-rabbit-arm:chaos__bf5e8a4__20221206"
+    ports:
+      - 1885:1885
+      - 4369:4369
+      - 5672:5672
+      - 15672:15672
+      - 15674:15674
+      - 25672:25672
+    environment:
+      - RABBITMQ_USERNAME=smqPublic
+      - RABBITMQ_PASSWORD=smqPublic
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq_management load_definitions "/tmp/rabbit_definitions.json"
+      - RABBITMQ_PLUGINS=rabbitmq_management,rabbitmq_stomp,rabbitmq_web_stomp,rabbitmq_mqtt
+    volumes:
+      - ./for_docker/dev_rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro

--- a/docker-x86.yml
+++ b/docker-x86.yml
@@ -1,0 +1,26 @@
+version: "3.5"
+
+networks:
+  dev:
+
+services:
+  rabbit:
+    container_name: gnf-rabbit
+    hostname: rabbit
+    networks:
+      - "dev"
+    image: "jessmillar/dev-rabbit-x86:chaos__bf5e8a4__20221206"
+    ports:
+      - 1885:1885
+      - 4369:4369
+      - 5672:5672
+      - 15672:15672
+      - 15674:15674
+      - 25672:25672
+    environment:
+      - RABBITMQ_USERNAME=smqPublic
+      - RABBITMQ_PASSWORD=smqPublic
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq_management load_definitions "/tmp/rabbit_definitions.json"
+      - RABBITMQ_PLUGINS=rabbitmq_management,rabbitmq_stomp,rabbitmq_web_stomp,rabbitmq_mqtt
+    volumes:
+      - ./for_docker/dev_rabbitmq.conf:/opt/bitnami/rabbitmq/etc/rabbitmq/rabbitmq.conf:ro

--- a/for_docker/dev_rabbitmq.conf
+++ b/for_docker/dev_rabbitmq.conf
@@ -1,0 +1,51 @@
+## Networking
+listeners.tcp.default = 5672
+
+loopback_users = none
+## On first start RabbitMQ will create a vhost and a user. These
+## config items control what gets created
+default_vhost = d1__1
+default_user = smqPublic
+default_pass = smqPublic
+default_permissions.configure = .*
+default_permissions.read = .*
+default_permissions.write = .*
+
+## Clustering
+cluster_partition_handling = ignore
+## Set a limit relative to total available RAM
+
+# The disk free space limit is configured with the disk_free_limit setting.
+# By default 50MB is required to be free on the database partition (see the
+# description of file locations , https://www.rabbitmq.com/relocate.html,
+# for the default database location). This  configuration file sets the disk
+# free space limit to 1GB
+
+# For now, comment out 1 GB and set it to default (50MB)
+
+
+# disk_free_limit.relative = 1.0
+
+## Management
+management.tcp.port = 15672
+management.tcp.ip = 0.0.0.0
+
+## Logging
+log.file.level = debug
+
+# Reg no TLS port is 1883; using 1885 in case dev machine has an mqtt broker on 1883
+mqtt.listeners.tcp.default = 1885
+## Default MQTT with TLS port is 8883
+# mqtt.listeners.ssl.default = 8883
+
+# anonymous connections, if allowed, will use the default
+# credentials specified here
+mqtt.allow_anonymous  = false
+mqtt.default_user     = smqPublic
+mqtt.default_pass     = smqPublic
+
+mqtt.vhost            = d1__1
+mqtt.exchange         = amq.topic
+# 24 hours by default
+mqtt.subscription_ttl = 86400000
+mqtt.prefetch         = 10

--- a/x86.sh
+++ b/x86.sh
@@ -1,0 +1,2 @@
+docker-compose -f docker-x86.yml down
+docker-compose -f docker-x86.yml up -d


### PR DESCRIPTION
Start with ./arm.sh  (arm machine) or ./x86 (x86 machine)

Uses these in .env:

 SCADA_GRIDWORKS_MQTT__HOST =  "localhost"
 SCADA_GRIDWORKS_MQTT__PORT = 1885
 SCADA_GRIDWORKS_MQTT__USERNAME = "smqPublic"
 SCADA_GRIDWORKS_MQTT__PASSWORD = "smqPublic"

 ATN_SCADA_MQTT__HOST = "localhost"
 ATN_SCADA_MQTT__PORT = 1885
 ATN_SCADA_MQTT__USERNAME = "smqPublic"
 ATN_SCADA_MQTT__PASSWORD = "smqPublic"