### PR TITLE
Acking cleanups

### DIFF
--- a/gw_spaceheat/proactor/logger.py
+++ b/gw_spaceheat/proactor/logger.py
@@ -74,6 +74,9 @@ class MessageSummary:
 
 
 class ProactorLogger(logging.LoggerAdapter):
+    MESSAGE_DELIMITER_WIDTH = 88
+    MESSAGE_ENTRY_DELIMITER = "+" * MESSAGE_DELIMITER_WIDTH
+    MESSAGE_EXIT_DELIMITER = "-" * MESSAGE_DELIMITER_WIDTH
 
     message_summary_logger: logging.Logger
     lifecycle_logger: logging.Logger
@@ -134,6 +137,18 @@ class ProactorLogger(logging.LoggerAdapter):
 
     def comm_event(self, msg: str, *args, **kwargs) -> None:
         self.comm_event_logger.info(msg, *args, **kwargs)
+
+    def message_enter(self, msg: str, *args, **kwargs):
+        if self.path_enabled:
+            self.path("")
+            self.path(self.MESSAGE_ENTRY_DELIMITER)
+            self.path(msg, *args, **kwargs)
+
+    def message_exit(self, msg: str, *args, **kwargs):
+        if self.path_enabled:
+            self.path(msg, *args, **kwargs)
+            self.path(self.MESSAGE_EXIT_DELIMITER)
+
 
     def __repr__(self):
         return (

--- a/gw_spaceheat/proactor/proactor_implementation.py
+++ b/gw_spaceheat/proactor/proactor_implementation.py
@@ -79,7 +79,7 @@ class AckWaitResult:
 
 
 LINK_POLL_SECONDS = 60
-
+import_time = time.time()
 
 @dataclass
 class MessageTimes:
@@ -93,7 +93,23 @@ class MessageTimes:
         return self.next_ping_second(link_poll_seconds) - time.time()
 
     def time_to_send_ping(self, link_poll_seconds: float) -> bool:
-        return time.time() > self.seconds_until_next_ping(link_poll_seconds)
+        return time.time() > self.next_ping_second(link_poll_seconds)
+
+    def get_str(self, link_poll_seconds: float = LINK_POLL_SECONDS, relative: bool = True) -> str:
+        if relative:
+            adjust = import_time
+        else:
+            adjust = 0
+        return (
+            f"n:{time.time() - adjust:5.2f}  lps:{link_poll_seconds:5.2f}  "
+            f"ls:{self.last_send - adjust:5.2f}  lr:{self.last_recv - adjust:5.2f}  "
+            f"nps:{self.next_ping_second(link_poll_seconds) - adjust:5.2f}  "
+            f"snp:{self.next_ping_second(link_poll_seconds):5.2f}  "
+            f"tsp:{int(self.time_to_send_ping(link_poll_seconds))}"
+        )
+
+    def __str__(self) -> str:
+        return self.get_str()
 
 
 class Proactor(ServicesInterface, Runnable):

--- a/tests/utils/scada2_recorder.py
+++ b/tests/utils/scada2_recorder.py
@@ -33,7 +33,7 @@ class LinkStats:
 
     @property
     def num_received(self) -> int:
-        return self.comm_event_counts[Message.type_name()]
+        return self.num_received_by_type[Message.type_name()]
 
     def __str__(self) -> str:
         s = f"LinkStats [{self.name}]  num_received: {self.num_received}  timeouts: {self.timeouts}  comm events: {len(self.comm_events)}"
@@ -62,6 +62,7 @@ class Stats:
 
     def __init__(self, link_names: Optional[Sequence[str]] = None):
         self.num_received_by_type = defaultdict(int)
+        self.num_received = 0
         if link_names is None:
             link_names = []
         self.links = {link_name: LinkStats(link_name) for link_name in link_names}
@@ -142,6 +143,7 @@ class Scada2Recorder(Scada2):
         else:
             self.stats.num_received_by_type[message.Header.MessageType] += 1
             if isinstance(message.Payload, MQTTReceiptPayload):
+                self.stats.links[message.Payload.client_name].num_received_by_type[Message.type_name()] += 1
                 self.stats.links[message.Payload.client_name].num_received_by_type[message.Header.MessageType] += 1
             await super().process_message(message)
 


### PR DESCRIPTION
* Resends now cancel old ack timer. Prior starting an ack timer, cancel any existing timer for the same message ID; A message can be re-sent before it's first ack timer expires if, for example, it is sent to mqtt prior to Atn startup, and then Atn starts up prior to timeout
* Messages sent now suppress sending ping