### PR TITLE
Exceptions in MQTT main loop no longer crash scada

### DIFF
--- a/gw_spaceheat/proactor/message.py
+++ b/gw_spaceheat/proactor/message.py
@@ -178,6 +178,7 @@ class MQTTDisconnectMessage(MQTTClientMessage[MQTTDisconnectPayload]):
             ),
         )
 
+
 class MQTTProblemsPayload(MQTTCommEventPayload):
     problems: Problems
 

--- a/gw_spaceheat/proactor/message.py
+++ b/gw_spaceheat/proactor/message.py
@@ -12,21 +12,22 @@ from typing import TypeVar
 from gwproto.message import ensure_arg
 from gwproto.message import Header
 from gwproto.message import Message
+from paho.mqtt.client import MQTT_ERR_UNKNOWN
 from paho.mqtt.client import MQTTMessage
 from pydantic import BaseModel
+
+from proactor.problems import Problems
+
 
 class MessageType(Enum):
     invalid = "invalid"
     mqtt_subscribe = "mqtt_subscribe"
     mqtt_message = "mqtt_message"
-
     mqtt_connected = "mqtt_connected"
     mqtt_disconnected = "mqtt_disconnected"
     mqtt_connect_failed = "mqtt_connect_failed"
-
     mqtt_suback = "mqtt_suback"
-
-    event_report = "event_report"
+    mqtt_problems = "mqtt_problems"
 
 class KnownNames(Enum):
     proactor = "proactor"
@@ -174,6 +175,24 @@ class MQTTDisconnectMessage(MQTTClientMessage[MQTTDisconnectPayload]):
                 client_name=client_name,
                 userdata=userdata,
                 rc=rc,
+            ),
+        )
+
+class MQTTProblemsPayload(MQTTCommEventPayload):
+    problems: Problems
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class MQTTProblemsMessage(MQTTClientMessage[MQTTCommEventPayload]):
+    def __init__(self, client_name: str, problems: Problems, rc: int = MQTT_ERR_UNKNOWN):
+        super().__init__(
+            message_type=MessageType.mqtt_problems,
+            payload=MQTTProblemsPayload(
+                client_name=client_name,
+                rc=rc,
+                problems=problems
             ),
         )
 

--- a/gw_spaceheat/proactor/mqtt.py
+++ b/gw_spaceheat/proactor/mqtt.py
@@ -9,6 +9,7 @@ Main current limitation: each interaction between asyncio code and the mqtt clie
 import asyncio
 import enum
 import logging
+import threading
 import uuid
 from typing import cast
 from typing import Dict
@@ -27,9 +28,11 @@ from proactor import config
 from proactor.message import MQTTConnectFailMessage
 from proactor.message import MQTTConnectMessage
 from proactor.message import MQTTDisconnectMessage
+from proactor.message import MQTTProblemsMessage
 from proactor.message import MQTTReceiptMessage
 from proactor.message import MQTTSubackMessage
 from proactor.message import MQTTSubackPayload
+from proactor.problems import Problems
 from proactor.sync_thread import AsyncQueueWriter
 
 class QOS(enum.IntEnum):
@@ -46,6 +49,7 @@ class MQTTClientWrapper:
     _name: str
     _client_config: config.MQTTClient
     _client: PahoMQTTClient
+    _stop_requested: bool
     _receive_queue: AsyncQueueWriter
     _subscriptions: Dict[str, int]
     _pending_subscriptions: Set[str]
@@ -73,14 +77,35 @@ class MQTTClientWrapper:
         self._subscriptions = dict()
         self._pending_subscriptions = set()
         self._pending_subacks = dict()
+        self._thread = threading.Thread(target=self._client_thread)
+        self._stop_requested = False
+
+    def _client_thread(self):
+        while not self._stop_requested:
+            try:
+                self._client.connect(self._client_config.host, port=self._client_config.port)
+                self._client.loop_forever(retry_first_connection=True)
+            except BaseException as e:
+                self._receive_queue.put(
+                    MQTTProblemsMessage(
+                        client_name=self.name,
+                        problems=Problems(errors=[e])
+                    )
+                )
+            finally:
+                # noinspection PyBroadException
+                try:
+                    self._client.disconnect()
+                except:
+                    pass
 
     def start(self):
-        self._client.connect(self._client_config.host, port=self._client_config.port)
-        self._client.loop_start()
+        self._thread.start()
 
     def stop(self):
+        self._stop_requested = True
         self._client.disconnect()
-        self._client.loop_stop()
+        self._thread.join()
 
     def publish(self, topic: str, payload: bytes, qos: int) -> MQTTMessageInfo:
         return self._client.publish(topic, payload, qos)

--- a/gw_spaceheat/proactor/proactor_implementation.py
+++ b/gw_spaceheat/proactor/proactor_implementation.py
@@ -432,7 +432,8 @@ class Proactor(ServicesInterface, Runnable):
 
     async def process_message(self, message: Message):
         if not isinstance(message.Payload, PatWatchdog):
-            self._logger.message_enter("++Proactor.process_message %s/%s", message.Header.Src, message.Header.MessageType)
+            self._logger.message_enter("++Proactor.process_message %s/%s",
+                                       message.Header.Src, message.Header.MessageType)
         path_dbg = 0
         if not isinstance(message.Payload, (MQTTReceiptPayload, PatWatchdog)):
             path_dbg |= 0x00000001

--- a/gw_spaceheat/proactor/problems.py
+++ b/gw_spaceheat/proactor/problems.py
@@ -1,3 +1,5 @@
+import textwrap
+import traceback
 from typing import Optional
 from typing import Sequence
 
@@ -53,6 +55,14 @@ class Problems(ValueError):
                         s += f"  {i:2d}: {entry}\n"
             return s
         return ""
+
+    def error_traceback_str(self) -> str:
+        s = ""
+        for i, error in enumerate(self.errors):
+            s += f"Traceback for error {i+1} / {len(self.errors)}:\n"
+            for line in traceback.format_exception(error):
+                s += textwrap.indent(line, "  ")
+        return s
 
     def __repr__(self) -> str:
         return str(self)

--- a/gw_spaceheat/proactor/sync_thread.py
+++ b/gw_spaceheat/proactor/sync_thread.py
@@ -20,20 +20,23 @@ def responsive_sleep(
     seconds: float,
     step_duration: float = DEFAULT_STEP_DURATION,
     running_field_name: str = "_main_loop_running",
+    running_field: bool = True,
 ) -> bool:
     """Sleep in way that is more responsive to thread termination: sleep in step_duration increments up to
-    specificed seconds, at after each step checking self._main_loop_running"""
+    specificed seconds, at after each step checking obj._main_loop_running. If the designated running_field_name actually
+    indicates that a stop has been requested (e.g. what you would expect from a field named '_stop_requested'),
+    set running_field parameter to False."""
     sleeps = int(seconds / step_duration)
     if sleeps * step_duration != seconds:
         last_sleep = seconds - (sleeps * step_duration)
     else:
         last_sleep = 0
     for _ in range(sleeps):
-        if getattr(obj, running_field_name):
+        if getattr(obj, running_field_name) == running_field:
             time.sleep(step_duration)
-    if getattr(obj, running_field_name) and last_sleep > 0:
+    if getattr(obj, running_field_name) == running_field and last_sleep > 0:
         time.sleep(last_sleep)
-    return getattr(obj, running_field_name)
+    return getattr(obj, running_field_name) == running_field
 
 class AsyncQueueWriter:
     """Allow synchronous code to write to an asyncio Queue.

--- a/gw_spaceheat/proactor/watchdog.py
+++ b/gw_spaceheat/proactor/watchdog.py
@@ -68,7 +68,7 @@ class WatchdogManager(Communicator, Runnable):
                 pass
 
     def process_message(self, message: Message) -> None:
-        self.lg.path("++WatchdogManager.process_message")
+        # self.lg.path("++WatchdogManager.process_message")
         path_dbg = 0
         match message.Payload:
             case PatInternalWatchdog():
@@ -80,7 +80,7 @@ class WatchdogManager(Communicator, Runnable):
             case _:
                 path_dbg |= 0x00000004
                 raise ValueError(f"WatchdogManager does not handle message payloads of type {type(message.Payload)}")
-        self.lg.path(f"--WatchdogManager.process_message  0x{path_dbg:08X}")
+        # self.lg.path(f"--WatchdogManager.process_message  0x{path_dbg:08X}")
 
     def _pat_internal_watchdog(self, name: str):
         if name not in self._monitored_names:


### PR DESCRIPTION
The mqtt loop is now run explicitly in a thread controlled by the proactor's MQTTClientWrapper, rather than implicitly by calling the client's loop_start() function. If the mqtt loop produces an exception, the scada will generate an activity report than wait an exponentially increasing amount of time (up to ~15 minutes) before trying to run the mqtt loop again. 