### PR TITLE
Makes TelemetryReportingConfig hashable

### DIFF
--- a/gw_spaceheat/schema/telemetry_reporting_config.py
+++ b/gw_spaceheat/schema/telemetry_reporting_config.py
@@ -307,6 +307,9 @@ class TelemetryReportingConfig(BaseModel):
     def as_type(self) -> str:
         return json.dumps(self.as_dict())
 
+    def __hash__(self):
+        return hash((type(self),) + tuple(self.__dict__.values())) # noqa
+
 
 class TelemetryReportingConfig_Maker:
     type_name = "telemetry.reporting.config"


### PR DESCRIPTION
Fixes #198. 

Note that this hand modifies generated file gw_spaceheat/schema/telemetry_reporting_config.py. 