### PR TITLE
Jm/params

### DIFF
--- a/docs/asls/json/keyparam-change-log.json
+++ b/docs/asls/json/keyparam-change-log.json
@@ -1,9 +1,9 @@
 {
   "gtr_asl": "001",
-  "type_name": "param.change.record",
+  "type_name": "keyparam.change.log",
   "version": "000",
   "owner": "gridworks@gridworks-consulting.com",
-  "description": "Param Change Record. The param.change.record type is designed for straightforward logging of important parameter changes in the SCADA and AtomicTNode code for transactive space-heating systems. Check out the details in [gridworks-atn]( https://github.com/thegridelectric/gridworks-atn) and [gw-scada-spaceheat-python](https://github.com/thegridelectric/gw-scada-spaceheat-python). It's made for humans—developers and system maintainers—to easily create and reference records of significant changes. Keep it short and sweet. We suggest using a "Before" and "After" attribute pattern to include the changed value, focusing for example on specific components rather than the entire hardware layout.",
+  "description": "Key Param Change Record. The keyparam.change.record type is designed for straightforward logging of important parameter changes in the SCADA and AtomicTNode code for transactive space-heating systems. Check out the details in [gridworks-atn]( https://github.com/thegridelectric/gridworks-atn) and [gw-scada-spaceheat-python](https://github.com/thegridelectric/gw-scada-spaceheat-python). It's made for humans—developers and system maintainers—to easily create and reference records of significant changes. Keep it short and sweet. We suggest using a "Before" and "After" attribute pattern to include the changed value, focusing for example on specific components rather than the entire hardware layout.",
   "properties": {
     "AboutNodeAlias": {
       "type": "string",
@@ -43,7 +43,7 @@
     },
     "TypeName": {
       "type": "string",
-      "value": "param.change.record",
+      "value": "keyparam.change.log",
       "title": "The type name"
     },
     "Version": {

--- a/docs/asls/types.rst
+++ b/docs/asls/types.rst
@@ -10,7 +10,7 @@ gt.sensor.reporting.config.100
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. literalinclude:: json/gt-sensor-reporting-config.json
 
-param.change.record.000
+keyparam.change.log.000
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. literalinclude:: json/param-change-record.json
+.. literalinclude:: json/keyparam-change-log.json
 

--- a/docs/sdk-types.rst
+++ b/docs/sdk-types.rst
@@ -20,5 +20,5 @@ forth between type instances and Python objects.
 
     GtPowermeterReportingConfig  <types/gt-powermeter-reporting-config>
     GtSensorReportingConfig  <types/gt-sensor-reporting-config>
-    ParamChangeRecord  <types/param-change-record>
+    KeyparamChangeLog  <types/keyparam-change-log>
     

--- a/docs/types/keyparam-change-log.rst
+++ b/docs/types/keyparam-change-log.rst
@@ -1,8 +1,8 @@
-KeyparamChangeRecord
+KeyparamChangeLog
 ==========================
-Python pydantic class corresponding to json type `keyparam.change.record`, version `000`.
+Python pydantic class corresponding to json type `keyparam.change.log`, version `000`.
 
-.. autoclass:: gwstypes.KeyparamChangeRecord
+.. autoclass:: gwstypes.KeyparamChangeLog
     :members:
 
 **AboutNodeAlias**:
@@ -33,14 +33,14 @@ Python pydantic class corresponding to json type `keyparam.change.record`, versi
 
 
 
-.. autoclass:: gwtypes.keyparam_change_record.check_is_left_right_dot
+.. autoclass:: gwtypes.keyparam_change_log.check_is_left_right_dot
     :members:
 
 
-.. autoclass:: gwtypes.keyparam_change_record.check_is_log_style_date_with_millis
+.. autoclass:: gwtypes.keyparam_change_log.check_is_log_style_date_with_millis
     :members:
 
 
-.. autoclass:: gwproto.types.KeyparamChangeRecord_Maker
+.. autoclass:: gwproto.types.KeyparamChangeLog_Maker
     :members:
 

--- a/gw_spaceheat/drivers/multipurpose_sensor/gridworks_tsnap1__multipurpose_sensor_driver.py
+++ b/gw_spaceheat/drivers/multipurpose_sensor/gridworks_tsnap1__multipurpose_sensor_driver.py
@@ -164,7 +164,7 @@ class TSnap1ConversionWarning(DriverWarning):
         s += f"   voltage: {self.voltage}  rt: {self.rt}  exception from rt calcuation: {self.rt_exception}  exception from celcius calculation: {self.c_exception}"
         return s
 
-PI_VOLTAGE = 5.1
+PI_VOLTAGE = 4.959
 # 298 Kelvin is 25 Celcius
 THERMISTOR_T0_DEGREES_KELVIN = 298
 # NTC THermistors are 10 kOhms at 25 deg C

--- a/gw_spaceheat/gwtypes/__init__.py
+++ b/gw_spaceheat/gwtypes/__init__.py
@@ -96,8 +96,8 @@ from gwtypes.gt_powermeter_reporting_config import GtPowermeterReportingConfig
 from gwtypes.gt_powermeter_reporting_config import GtPowermeterReportingConfig_Maker
 from gwtypes.gt_sensor_reporting_config import GtSensorReportingConfig
 from gwtypes.gt_sensor_reporting_config import GtSensorReportingConfig_Maker
-from gwtypes.keyparam_change_record import KeyparamChangeRecord
-from gwtypes.keyparam_change_record import KeyparamChangeRecord_Maker
+from gwtypes.keyparam_change_log import KeyparamChangeLog
+from gwtypes.keyparam_change_log import KeyparamChangeLog_Maker
 
 
 __all__ = [
@@ -157,8 +157,8 @@ __all__ = [
     "HubitatTankCacGt_Maker",
     "HubitatTankComponentGt",
     "HubitatTankComponentGt_Maker",
-    "KeyparamChangeRecord",
-    "KeyparamChangeRecord_Maker",
+    "KeyparamChangeLog",
+    "KeyparamChangeLog_Maker",
     "MultipurposeSensorCacGt",
     "MultipurposeSensorCacGt_Maker",
     "MultipurposeSensorComponentGt",

--- a/gw_spaceheat/gwtypes/gt_powermeter_reporting_config.py
+++ b/gw_spaceheat/gwtypes/gt_powermeter_reporting_config.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger(__name__)
 
 class GtPowermeterReportingConfig(BaseModel):
     """
-    Power Meter Rep.
+    Power Meter Reporting Config.
 
     Contains data used to configure the power meters used to monitor and confirm the energy
     and power use of Transactive Loads. It is designed to be used, for example, by the SpaceheatNode

--- a/gw_spaceheat/gwtypes/keyparam_change_log.py
+++ b/gw_spaceheat/gwtypes/keyparam_change_log.py
@@ -1,4 +1,4 @@
-"""Type keyparam.change.record, version 000"""
+"""Type keyparam.change.log, version 000"""
 import json
 import logging
 from typing import Any, Dict, Literal
@@ -16,7 +16,7 @@ LOG_FORMAT = (
 LOGGER = logging.getLogger(__name__)
 
 
-class KeyparamChangeRecord(BaseModel):
+class KeyparamChangeLog(BaseModel):
     """
     Key Param Change Record.
 
@@ -68,7 +68,7 @@ class KeyparamChangeRecord(BaseModel):
             "and its use within the relevant code base."
         ),
     )
-    TypeName: Literal["keyparam.change.record"] = "keyparam.change.record"
+    TypeName: Literal["keyparam.change.log"] = "keyparam.change.log"
     Version: Literal["000"] = "000"
 
     class Config:
@@ -97,11 +97,11 @@ class KeyparamChangeRecord(BaseModel):
     def as_dict(self) -> Dict[str, Any]:
         """
         Translate the object into a dictionary representation that can be serialized into a
-        keyparam.change.record.000 object.
+        keyparam.change.log.000 object.
 
         This method prepares the object for serialization by the as_type method, creating a
         dictionary with key-value pairs that follow the requirements for an instance of the
-        keyparam.change.record.000 type. Unlike the standard python dict method,
+        keyparam.change.log.000 type. Unlike the standard python dict method,
         it makes the following substantive changes:
         - Enum Values: Translates between the values used locally by the actor to the symbol
         sent in messages.
@@ -123,10 +123,10 @@ class KeyparamChangeRecord(BaseModel):
 
     def as_type(self) -> bytes:
         """
-        Serialize to the keyparam.change.record.000 representation.
+        Serialize to the keyparam.change.log.000 representation.
 
-        Instances in the class are python-native representations of keyparam.change.record.000
-        objects, while the actual keyparam.change.record.000 object is the serialized UTF-8 byte
+        Instances in the class are python-native representations of keyparam.change.log.000
+        objects, while the actual keyparam.change.log.000 object is the serialized UTF-8 byte
         string designed for sending in a message.
 
         This method calls the as_dict() method, which differs from the native python dict()
@@ -138,7 +138,7 @@ class KeyparamChangeRecord(BaseModel):
 
         It also applies these changes recursively to sub-types.
 
-        Its near-inverse is KeyparamChangeRecord.type_to_tuple(). If the type (or any sub-types)
+        Its near-inverse is KeyparamChangeLog.type_to_tuple(). If the type (or any sub-types)
         includes an enum, then the type_to_tuple will map an unrecognized symbol to the
         default enum value. This is why these two methods are only 'near' inverses.
         """
@@ -149,8 +149,8 @@ class KeyparamChangeRecord(BaseModel):
         return hash((type(self),) + tuple(self.__dict__.values()))  # noqa
 
 
-class KeyparamChangeRecord_Maker:
-    type_name = "keyparam.change.record"
+class KeyparamChangeLog_Maker:
+    type_name = "keyparam.change.log"
     version = "000"
 
     def __init__(
@@ -162,7 +162,7 @@ class KeyparamChangeRecord_Maker:
         description: str,
         kind: KindOfParam,
     ):
-        self.tuple = KeyparamChangeRecord(
+        self.tuple = KeyparamChangeLog(
             AboutNodeAlias=about_node_alias,
             ChangeTimeUtc=change_time_utc,
             Author=author,
@@ -172,14 +172,14 @@ class KeyparamChangeRecord_Maker:
         )
 
     @classmethod
-    def tuple_to_type(cls, tuple: KeyparamChangeRecord) -> bytes:
+    def tuple_to_type(cls, tuple: KeyparamChangeLog) -> bytes:
         """
         Given a Python class object, returns the serialized JSON type object.
         """
         return tuple.as_type()
 
     @classmethod
-    def type_to_tuple(cls, t: bytes) -> KeyparamChangeRecord:
+    def type_to_tuple(cls, t: bytes) -> KeyparamChangeLog:
         """
         Given a serialized JSON type object, returns the Python class object.
         """
@@ -192,12 +192,12 @@ class KeyparamChangeRecord_Maker:
         return cls.dict_to_tuple(d)
 
     @classmethod
-    def dict_to_tuple(cls, d: dict[str, Any]) -> KeyparamChangeRecord:
+    def dict_to_tuple(cls, d: dict[str, Any]) -> KeyparamChangeLog:
         """
-        Deserialize a dictionary representation of a keyparam.change.record.000 message object
-        into a KeyparamChangeRecord python object for internal use.
+        Deserialize a dictionary representation of a keyparam.change.log.000 message object
+        into a KeyparamChangeLog python object for internal use.
 
-        This is the near-inverse of the KeyparamChangeRecord.as_dict() method:
+        This is the near-inverse of the KeyparamChangeLog.as_dict() method:
           - Enums: translates between the symbols sent in messages between actors and
         the values used by the actors internally once they've deserialized the messages.
           - Types: recursively validates and deserializes sub-types.
@@ -210,10 +210,10 @@ class KeyparamChangeRecord_Maker:
             d (dict): the dictionary resulting from json.loads(t) for a serialized JSON type object t.
 
         Raises:
-           SchemaError: if the dict cannot be turned into a KeyparamChangeRecord object.
+           SchemaError: if the dict cannot be turned into a KeyparamChangeLog object.
 
         Returns:
-            KeyparamChangeRecord
+            KeyparamChangeLog
         """
         d2 = dict(d)
         if "AboutNodeAlias" not in d2.keys():
@@ -237,10 +237,10 @@ class KeyparamChangeRecord_Maker:
             raise SchemaError(f"Version missing from dict <{d2}>")
         if d2["Version"] != "000":
             LOGGER.debug(
-                f"Attempting to interpret keyparam.change.record version {d2['Version']} as version 000"
+                f"Attempting to interpret keyparam.change.log version {d2['Version']} as version 000"
             )
             d2["Version"] = "000"
-        return KeyparamChangeRecord(**d2)
+        return KeyparamChangeLog(**d2)
 
 
 def check_is_left_right_dot(v: str) -> None:

--- a/gw_spaceheat/layout_gen/__init__.py
+++ b/gw_spaceheat/layout_gen/__init__.py
@@ -4,7 +4,7 @@ from layout_gen.egauge import add_egauge
 from layout_gen.egauge import EGaugeGenCfg
 from layout_gen.egauge import EGaugeIOGenCfg
 from layout_gen.flow import add_flow_meter
-from layout_gen.flow import add_istech_flow_meter
+from layout_gen.flow import add_istec_flow_meter
 from layout_gen.hubitat import add_hubitat
 from layout_gen.layout_db import LayoutDb
 from layout_gen.layout_db import LayoutIDMap
@@ -20,7 +20,7 @@ from layout_gen.tank import add_tank
 __all__ = [
     "add_egauge",
     "add_flow_meter",
-    "add_istech_flow_meter",
+    "add_istec_flow_meter",
     "add_hubitat_poller",
     "add_hubitat_thermostat",
     "add_tank",

--- a/gw_spaceheat/layout_gen/egauge.py
+++ b/gw_spaceheat/layout_gen/egauge.py
@@ -27,6 +27,7 @@ class EGaugeIOGenCfg(BaseModel):
     EGuageName: str
     NameplateMaxValue: int = 3500
     AsyncReportThreshold: float = 0.02
+    InPowerMetering: bool = False
 
     def output_config(self, **kwargs) -> TelemetryReportingConfig:
         kwargs_used = dict(
@@ -61,6 +62,7 @@ class EGaugeIOGenCfg(BaseModel):
             ActorClass=ActorClass.NoActor,
             Role=self.NodeRole,
             DisplayName=self.NodeDisplayName,
+            InPowerMetering=self.InPowerMetering,
         )
 
     def egauge_io(

--- a/gw_spaceheat/layout_gen/egauge.py
+++ b/gw_spaceheat/layout_gen/egauge.py
@@ -25,6 +25,8 @@ class EGaugeIOGenCfg(BaseModel):
     NodeDisplayName: str
     EGaugeAddress: int
     EGuageName: str
+    NameplateMaxValue: int = 3500
+    AsyncReportThreshold: float = 0.02
 
     def output_config(self, **kwargs) -> TelemetryReportingConfig:
         kwargs_used = dict(
@@ -34,8 +36,8 @@ class EGaugeIOGenCfg(BaseModel):
             SamplePeriodS=300,
             Exponent=0,
             Unit=UnitEnum.W,
-            AsyncReportThreshold=0.02,
-            NameplateMaxValue=3500,
+            NameplateMaxValue=self.NameplateMaxValue,
+            AsyncReportThreshold=self.AsyncReportThreshold,
         )
         kwargs_used.update(kwargs)
         return TelemetryReportingConfig(**kwargs_used)

--- a/gw_spaceheat/layout_gen/flow.py
+++ b/gw_spaceheat/layout_gen/flow.py
@@ -27,12 +27,17 @@ class FlowMeterGenCfg(BaseModel):
     def component_alias(self) -> str:
         return f"Pipe Flow Meter Component <{self.NodeAlias}>"
 
-class iSTECHFlowMeterGenCfg(FlowMeterGenCfg):
-    ConversionFactor: float = 0.332
+class Istec4440FlowMeterGenCfg(FlowMeterGenCfg):
+    ConversionFactor: float = 0.268
 
-class OmegaFlowMeterGenCfg(FlowMeterGenCfg):
-    ConversionFactor: float = 1/2.64
+class SmallOmegaFlowMeterGenCfg(FlowMeterGenCfg):
+    # For the Omega FTB8007 series that give a tick every 0.1 gallons
+    ConversionFactor: float = 0.134
 
+
+class LargeOmegaFlowMeterGenCfg(FlowMeterGenCfg):
+    # For the Omega FTB8010 series that give a tick every gallon
+    ConversionFactor: float = 1.34
 
 
 def add_flow_meter(
@@ -84,8 +89,9 @@ def add_flow_meter(
         ]
     )
 
-def add_istech_flow_meter(
+def add_istec_flow_meter(
     db: LayoutDb,
-    flow_meter: iSTECHFlowMeterGenCfg,
+    flow_meter: Istec4440FlowMeterGenCfg,
 ) -> None:
     return add_flow_meter(db, flow_meter)
+

--- a/gw_spaceheat/layout_gen/flow.py
+++ b/gw_spaceheat/layout_gen/flow.py
@@ -28,16 +28,16 @@ class FlowMeterGenCfg(BaseModel):
         return f"Pipe Flow Meter Component <{self.NodeAlias}>"
 
 class Istec4440FlowMeterGenCfg(FlowMeterGenCfg):
-    ConversionFactor: float = 0.268
+    ConversionFactor: float = 0.268132
 
 class SmallOmegaFlowMeterGenCfg(FlowMeterGenCfg):
     # For the Omega FTB8007 series that give a tick every 0.1 gallons
-    ConversionFactor: float = 0.134
+    ConversionFactor: float = 0.134066
 
 
 class LargeOmegaFlowMeterGenCfg(FlowMeterGenCfg):
     # For the Omega FTB8010 series that give a tick every gallon
-    ConversionFactor: float = 1.34
+    ConversionFactor: float = 1.34066
 
 
 def add_flow_meter(

--- a/gw_spaceheat/layout_gen/flow.py
+++ b/gw_spaceheat/layout_gen/flow.py
@@ -40,6 +40,16 @@ class LargeOmegaFlowMeterGenCfg(FlowMeterGenCfg):
     ConversionFactor: float = 1.34066
 
 
+class PrmFiltrationWm075FlowMeterGenCfg(FlowMeterGenCfg):
+    # For the PRM Filtration WM075 series that give a tick every gallon
+    ConversionFactor: float = 1.34066
+
+
+class KeyenceFlowMeterGenCfg(FlowMeterGenCfg):
+    # For a Keyence series that give a tick every 0.1 gallons
+    ConversionFactor: float =  0.134066
+
+
 def add_flow_meter(
     db: LayoutDb,
     flow_meter: FlowMeterGenCfg,

--- a/gw_spaceheat/layout_gen/poller.py
+++ b/gw_spaceheat/layout_gen/poller.py
@@ -130,7 +130,7 @@ def add_hubitat_thermostat(
                         unit_gt_enum_symbol="7d8832f8",
                     ),
                     display_name=thermostat.display_name + " Heating Set Point",
-                    role=Role.ThermostatHeatingSetPoint,
+                    role=Role.Unknown,
                 ),
             ],
             poll_period_seconds=thermostat.poll_period_seconds,

--- a/gw_spaceheat/param_report_script.py
+++ b/gw_spaceheat/param_report_script.py
@@ -1,0 +1,66 @@
+import dotenv
+import pendulum
+from gwproto.data_classes.hardware_layout import HardwareLayout
+
+from actors.config import ScadaSettings
+from enums import KindOfParam
+from gwtypes import KeyparamChangeLog_Maker as Maker
+
+settings = ScadaSettings(_env_file=dotenv.find_dotenv())
+
+layout = HardwareLayout.load(settings.paths.hardware_layout)
+scada_alias = layout.layout["MyScadaGNode"]["Alias"]
+
+author = input("Your name:\n")
+
+key_param_name = input("Name of the key param: \n")
+
+print("What kind of param is this?")
+for val in KindOfParam.values():
+    print(f"    {val}")
+
+kind = input("Select one of the above\n")
+
+before = input("Before\n")
+
+after = input("After\n")
+
+description = input("Description\n")
+
+
+d = {
+    "AboutNodeAlias": f"{scada_alias}",
+    "ChangeTimeUtc": pendulum.now().format("YYYY-MM-DDTHH:mm:ss.SSS"),
+    "Author": f"{author}",
+    "ParamName": f"{key_param_name}",
+    "Description": f"{description}",
+    "KindGtEnumSymbol": f"{KindOfParam.value_to_symbol(kind)}",
+    "Before": before,
+    "After": after,
+    "TypeName": "keyparam.change.log",
+    "Version": "000",
+}
+
+print(d)
+c = Maker.dict_to_tuple(d)
+msg = Maker.tuple_to_type(c)
+
+print(msg)
+
+s = input("Press any key to continue ...")
+
+topic = f"gw/{scada_alias}/{c.TypeName}".replace(".", "-")
+
+mqtt_command = (
+    f"mosquitto_pub -h '{settings.gridworks_mqtt.host}' -p {settings.gridworks_mqtt.tls.port} \ \n"
+    f"--cafile {settings.gridworks_mqtt.tls.paths.ca_cert_path} \ \n"
+    f"--cert {settings.gridworks_mqtt.tls.paths.cert_path} \ \n"
+    f"--key {settings.gridworks_mqtt.tls.paths.private_key_path} \ \n"
+    f"-u '{settings.gridworks_mqtt.username}' -P '{settings.gridworks_mqtt.password.get_secret_value()}' \ \n"
+    f"-t '{topic}' -m {msg}"
+)
+
+
+print("TRY SENDING THIS:\n")
+
+print(mqtt_command)

--- a/tests/types/test_keyparam_change_log.py
+++ b/tests/types/test_keyparam_change_log.py
@@ -1,15 +1,15 @@
-"""Tests keyparam.change.record type, version 000"""
+"""Tests keyparam.change.log type, version 000"""
 import json
 
 import pytest
 from pydantic import ValidationError
 
 from gridworks.errors import SchemaError
-from gwtypes import KeyparamChangeRecord_Maker as Maker
+from gwtypes import KeyparamChangeLog_Maker as Maker
 from enums import KindOfParam
 
 
-def test_keyparam_change_record_generated() -> None:
+def test_keyparam_change_log_generated() -> None:
     d = {
         "AboutNodeAlias": "hw1.isone.me.versant.keene.beech.scada",
         "ChangeTimeUtc": "2022-06-25T12:30:45.678",
@@ -17,9 +17,9 @@ def test_keyparam_change_record_generated() -> None:
         "ParamName": "AdsMaxVoltage",
         "Description": "The maximum voltage used by thermistor temp sensing that rely on the ADS I2C chip. This transitions from being part of the code (pre) to part of the hardware layout (post)",
         "KindGtEnumSymbol": "00000000",
-        "TypeName": "keyparam.change.record",
         "Before": 5.1,
         "After": 4.9,
+        "TypeName": "keyparam.change.log",
         "Version": "000",
     }
 
@@ -60,6 +60,7 @@ def test_keyparam_change_record_generated() -> None:
         kind=gtuple2.Kind,
     ).tuple
     assert t2 == gtuple2
+	
 
     ######################################
     # SchemaError raised if missing a required attribute


### PR DESCRIPTION
- Create a params report message, and a script for sending one up by hand, for when a critical parameter is changed in a way that might get lost in the sands of time (e.g. the max voltage used for the voltage divider formula in calculating thermistor temps from voltages)
- Add a number of new flow meters to layout_gen/flow to reflect what is happening in the field
- Update layout_gen/egauge to clarify which nodes are in the transactive power reporting (InPowerMetering), and also to clarify the NameplateMaxValue to get better async readings on pumps etc