### PR TITLE
Scada2 subscribes to topic published to by scada link management

### DIFF
--- a/gw_spaceheat/actors/parentless.py
+++ b/gw_spaceheat/actors/parentless.py
@@ -161,7 +161,12 @@ class Parentless(ScadaInterface, Proactor):
                         ),
                     Payload=message.Payload
                 )
-                self._links.publish_message(Parentless.LOCAL_MQTT, new_msg, QOS.AtMostOnce)
+                self._links.publish_message(
+                    Parentless.LOCAL_MQTT,
+                    new_msg,
+                    QOS.AtMostOnce,
+                    use_link_topic=True,
+                )
             case SyncedReadings():
                 path_dbg |= 0x00000004
                 new_msg = Message(
@@ -172,7 +177,12 @@ class Parentless(ScadaInterface, Proactor):
                         ),
                     Payload=message.Payload
                 )
-                self._links.publish_message(Parentless.LOCAL_MQTT, new_msg, QOS.AtMostOnce)
+                self._links.publish_message(
+                    Parentless.LOCAL_MQTT,
+                    new_msg,
+                    QOS.AtMostOnce,
+                    use_link_topic=True,
+                )
             case _:
                 raise ValueError(
                     f"There is no handler for message payload type [{type(message.Payload)}]"

--- a/gw_spaceheat/actors/parentless.py
+++ b/gw_spaceheat/actors/parentless.py
@@ -38,6 +38,7 @@ class Parentless(ScadaInterface, Proactor):
     DEFAULT_ACTORS_MODULE = "actors"
     LOCAL_MQTT = "local"
     _data: Scada2Data
+    _publication_name: str
 
     def __init__(
         self,
@@ -48,7 +49,9 @@ class Parentless(ScadaInterface, Proactor):
     ):
         if type(hardware_layout) is not House0Layout:
             raise Exception(f"hardware_layout is of type {type(hardware_layout)}!!")
+        self._publication_name = f"{hardware_layout.scada_g_node_alias}.{name}"
         super().__init__(name=name, settings=settings, hardware_layout=hardware_layout)
+        remote_node_names: set[str] = {self._layout.scada_g_node_alias.replace(".", "-")}
         self._links.add_mqtt_link(
             LinkSettings(
                 client_name=Parentless.LOCAL_MQTT,
@@ -57,7 +60,7 @@ class Parentless(ScadaInterface, Proactor):
                 mqtt=self.settings.local_mqtt,
                 codec=LocalMQTTCodec(
                     primary_scada=False,
-                    remote_node_names=set([self._layout.scada_g_node_alias.replace(".", "-")]),
+                    remote_node_names=remote_node_names,
                 ),
                 upstream=True,
             )
@@ -118,6 +121,10 @@ class Parentless(ScadaInterface, Proactor):
         return H0N.secondary_scada
 
     @property
+    def publication_name(self) -> str:
+        return self._publication_name
+
+    @property
     def node(self) -> ShNode:
         return self._node
 
@@ -134,8 +141,12 @@ class Parentless(ScadaInterface, Proactor):
         return self._layout
 
     def _publish_to_local(self, from_node: ShNode, payload, qos: QOS = QOS.AtMostOnce):
-        message = Message(Src=from_node.Name, Payload=payload)
-        return self._links.publish_message(Parentless.LOCAL_MQTT, message, qos=qos)
+        return self._links.publish_message(
+            Parentless.LOCAL_MQTT,
+            Message(Src=from_node.Name, Payload=payload),
+            qos=qos,
+            use_link_topic=True
+        )
 
     def _derived_process_message(self, message: Message):
         self._logger.path("++Parentless._derived_process_message %s/%s", message.Header.Src, message.Header.MessageType)

--- a/gw_spaceheat/actors/parentless.py
+++ b/gw_spaceheat/actors/parentless.py
@@ -52,12 +52,12 @@ class Parentless(ScadaInterface, Proactor):
         self._links.add_mqtt_link(
             LinkSettings(
                 client_name=Parentless.LOCAL_MQTT,
-                gnode_name=H0N.primary_scada,
+                gnode_name=self._layout.scada_g_node_alias,
                 spaceheat_name=H0N.primary_scada,
                 mqtt=self.settings.local_mqtt,
                 codec=LocalMQTTCodec(
                     primary_scada=False,
-                    remote_node_names=set(),
+                    remote_node_names=set([self._layout.scada_g_node_alias.replace(".", "-")]),
                 ),
                 upstream=True,
             )
@@ -112,6 +112,10 @@ class Parentless(ScadaInterface, Proactor):
     @property
     def name(self):
         return self._name
+
+    @property
+    def subscription_name(self) -> str:
+        return H0N.secondary_scada
 
     @property
     def node(self) -> ShNode:

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -216,17 +216,6 @@ class Scada(ScadaInterface, Proactor):
                 upstream=True,
             )
         )
-        for node_name in remote_actor_node_names:
-            self._links.subscribe(
-                client=self.LOCAL_MQTT,
-                topic=MQTTTopic.encode(
-                    envelope_type=Message.type_name(),
-                    src=node_name,
-                    dst=self.subscription_name,
-                    message_type="#",
-                ),
-                qos=QOS.AtMostOnce,
-            )
         if self.settings.admin.enabled:
             self._links.add_mqtt_link(
                 LinkSettings(

--- a/gw_spaceheat/requirements/base.in
+++ b/gw_spaceheat/requirements/base.in
@@ -11,7 +11,7 @@ transitions
 gridworks-protocol >=1.2.1
 # gridworks-protocol @ git+https://github.com/thegridelectric/gridworks-protocol.git@dev
 
-gridworks-proactor >=1.1.5
+gridworks-proactor >=1.1.6
 # gridworks-proactor @ git+https://github.com/thegridelectric/gridworks-proactor.git@dev
 smbus2
 pymodbus

--- a/gw_spaceheat/requirements/base.txt
+++ b/gw_spaceheat/requirements/base.txt
@@ -35,7 +35,7 @@ frozenlist==1.4.0
     #   aiosignal
 gridworks==1.2.0
     # via gridworks-protocol
-gridworks-proactor==1.1.4
+gridworks-proactor==1.1.6
     # via -r gw_spaceheat/requirements/base.in
 gridworks-protocol==1.2.1
     # via

--- a/gw_spaceheat/requirements/dev.in
+++ b/gw_spaceheat/requirements/dev.in
@@ -3,7 +3,7 @@
 pip-tools
 isort
 
-gridworks-proactor[tests] >=1.1.5
+gridworks-proactor[tests] >=1.1.6
 # gridworks-proactor[tests] @ git+https://github.com/thegridelectric/gridworks-proactor.git@dev
 gridworks-cert>=0.4.4
 requests # for atn dashboard

--- a/gw_spaceheat/requirements/dev.txt
+++ b/gw_spaceheat/requirements/dev.txt
@@ -55,7 +55,7 @@ gridworks-cert==0.4.4
     # via
     #   -r gw_spaceheat/requirements/dev.in
     #   gridworks-proactor
-gridworks-proactor[tests]==1.1.5
+gridworks-proactor[tests]==1.1.6
     # via
     #   -r /Users/Andrew/git/gridworks/gw-scada-spaceheat-python/gw_spaceheat/requirements/base.in
     #   -r /Users/Andrew/git/gridworks/gw-scada-spaceheat-python/gw_spaceheat/requirements/test.in

--- a/gw_spaceheat/requirements/drivers.txt
+++ b/gw_spaceheat/requirements/drivers.txt
@@ -67,7 +67,7 @@ frozenlist==1.4.0
     #   aiosignal
 gridworks==1.2.0
     # via gridworks-protocol
-gridworks-proactor==1.1.5
+gridworks-proactor==1.1.6
     # via -r /Users/Andrew/git/gridworks/gw-scada-spaceheat-python/gw_spaceheat/requirements/base.in
 gridworks-protocol==1.2.1
     # via

--- a/gw_spaceheat/requirements/test.in
+++ b/gw_spaceheat/requirements/test.in
@@ -2,6 +2,6 @@ pytest
 coverage
 mypy
 black
-gridworks-proactor[tests] >=1.1.5
+gridworks-proactor[tests] >=1.1.6
 # gridworks-proactor[tests] @ git+https://github.com/thegridelectric/gridworks-proactor.git@dev
 pytest-asyncio

--- a/gw_spaceheat/requirements/test.txt
+++ b/gw_spaceheat/requirements/test.txt
@@ -43,7 +43,7 @@ gridworks==1.2.0
     # via gridworks-protocol
 gridworks-cert==0.4.3
     # via gridworks-proactor
-gridworks-proactor[tests]==1.1.5
+gridworks-proactor[tests]==1.1.6
     # via -r gw_spaceheat/requirements/test.in
 gridworks-protocol==1.2.1
     # via gridworks-proactor


### PR DESCRIPTION
Note that comm between Scada and Scada2 would use the gnode of the scada in the topics, e.g.: 
```
2025-01-16 16:04:45.220   OUT mqtt         hw1.isone.eversource.almond.scada to s2                ->  [gw/hw1-isone-eversource-almond-scada/to/s2/gridworks-ack]                        Ack                       b95af63c...
2025-01-16 16:04:45.221   IN  mqtt         s2 to s                                                <-  [gw/s2/to/s/gridworks-event-problem]                                              ProblemEvent              5474b5cd...
2025-01-16 16:04:45.221   OUT mqtt         hw1.isone.eversource.almond.scada to s2                ->  [gw/hw1-isone-eversource-almond-scada/to/s2/gridworks-ack]                        Ack                       5474b5cd...
2025-01-16 16:04:45.221   IN  mqtt         s2 to s                                                <-  [gw/s2/to/s/gridworks-event-problem]                                              ProblemEvent              e10286cf...

```

We can change this with a little more more work (a few lines - probably an hour with testing). 