### PR TITLE
AllyGivesUp and goes back to HomeAlone if no forecasts

### DIFF
--- a/gw_spaceheat/enums/main_auto_event.py
+++ b/gw_spaceheat/enums/main_auto_event.py
@@ -10,8 +10,10 @@ class MainAutoEvent(GwStrEnum):
     Values:
       - AtnLinkDead
       - AtnWantsControl
+      - AtnReleasesControl
       - AutoGoesDormant
       - AutoWakesUp
+      - AllyGivesUp
 
     For more information:
       - [ASLs](https://gridworks-type-registry.readthedocs.io/en/latest/)
@@ -20,8 +22,10 @@ class MainAutoEvent(GwStrEnum):
 
     AtnLinkDead = auto()
     AtnWantsControl = auto()
+    AtnReleasesControl = auto()
     AutoGoesDormant = auto()
     AutoWakesUp = auto()
+    AllyGivesUp = auto()
 
     @classmethod
     def default(cls) -> "MainAutoEvent":

--- a/gw_spaceheat/named_types/__init__.py
+++ b/gw_spaceheat/named_types/__init__.py
@@ -4,6 +4,7 @@ from named_types.admin_dispatch import AdminDispatch
 from named_types.admin_keep_alive import AdminKeepAlive
 from named_types.admin_release_control import AdminReleaseControl
 from named_types.atn_bid import AtnBid
+from named_types.ally_gives_up import AllyGivesUp
 from named_types.channel_flatlined import ChannelFlatlined
 from named_types.dispatch_contract_go_dormant import DispatchContractGoDormant
 from named_types.dispatch_contract_go_live import DispatchContractGoLive
@@ -34,6 +35,7 @@ __all__ = [
     "AdminDispatch",
     "AdminKeepAlive",
     "AdminReleaseControl",
+    "AllyGivesUp",
     "AtnBid",
     "ChannelFlatlined",
     "DispatchContractGoDormant",

--- a/gw_spaceheat/named_types/ally_gives_up.py
+++ b/gw_spaceheat/named_types/ally_gives_up.py
@@ -1,0 +1,14 @@
+"""Type ally.gives.up, version 000"""
+
+from typing import Literal
+
+from gwproto.property_format import SpaceheatName
+from pydantic import BaseModel
+
+
+class AllyGivesUp(BaseModel):
+    FromName: SpaceheatName
+    ToName: SpaceheatName
+    Reason: str  # This allows us to communicate why we're giving up
+    TypeName: Literal["ally.gives.up"] = "ally.gives.up"
+    Version: Literal["000"] = "000"

--- a/tests/enums/main_auto_event_test.py
+++ b/tests/enums/main_auto_event_test.py
@@ -11,6 +11,8 @@ def test_main_auto_event() -> None:
         "AtnWantsControl",
         "AutoGoesDormant",
         "AutoWakesUp",
+        "AtnReleasesControl",
+        "AllyGivesUp",
     }
 
     assert MainAutoEvent.default() == MainAutoEvent.AutoGoesDormant


### PR DESCRIPTION
Adds graceful handling when AtomicAlly cannot participate in dispatch contract

- Adds AllyGivesUp message type and state transition
- Implements suit_up() method in AtomicAlly to verify prerequisites
- Adds state transition handling in Scada for AtomicAlly decline
- Ensures proper command tree updates and HomeAlone reactivation

This PR improves system resilience by properly handling cases where AtomicAlly cannot 
participate in a dispatch contract (e.g., missing forecasts). The changes ensure the 
system remains in a consistent state by reverting to HomeAlone mode with appropriate 
command tree structure.

TODO in future PR: Add Scada -> Atn communication for dispatch contract state.