### PR TITLE
handle stale modbus

### DIFF
--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -647,12 +647,23 @@ class Scada(ScadaInterface, Proactor):
     ) -> None:
         self._logger.path("++_process_downstream_mqtt_message %s", message.Payload.message.topic)
         path_dbg = 0
+        from_node = self._layout.node(message.Header.Src, None)
         match decoded.Payload:
             case EventBase():
                 path_dbg |= 0x00000001
                 self.generate_event(decoded.Payload)
-            case SyncedReadings():
+            case PowerWatts():
                 path_dbg |= 0x00000002
+                if from_node is self._layout.power_meter_node:
+                    path_dbg |= 0x00000002
+                    self.power_watts_received(message.Payload)
+                    self.get_communicator(H0N.synth_generator).process_message(message)
+                else:
+                    raise Exception(
+                        f"message.Header.Src {message.Header.Src} must be from {self._layout.power_meter_node} for PowerWatts message"
+                    )
+            case SyncedReadings():
+                path_dbg |= 0x00000004
                 try:
                     self.synced_readings_received(
                         self._layout.node(decoded.Header.Src),
@@ -663,7 +674,7 @@ class Scada(ScadaInterface, Proactor):
                     self.logger.error(f"Failed to process SyncedReading from scada2!: {e}")
             case _:
                 # Intentionally ignore this for forward compatibility
-                path_dbg |= 0x00000004
+                path_dbg |= 0x00000008
         self._logger.path("--_process_downstream_mqtt_message  path:0x%08X", path_dbg)
 
     def _process_admin_mqtt_message(


### PR DESCRIPTION
Changes to the egauge modbus driver, specifically going for:
  1) try_connect short and clear in its logic
  2) flush the modbus client if it exists but cannot read

Added a ModbusClientStale error type to differentiate between the case where the modbus client is not open vs is apparently open but not returning values.