### PR TITLE
Various bus squashed and changes

### DIFF
--- a/gw_spaceheat/actors/config.py
+++ b/gw_spaceheat/actors/config.py
@@ -47,7 +47,6 @@ class ScadaSettings(ProactorSettings):
     max_ewt_f: int = 170
     load_overestimation_percent: int = 0
     oil_boiler_for_onpeak_backup: bool = True
-    fuel_substitution: bool = True
     hp_model: HpModel = HpModel.SamsungHighTempHydroKitPlusMultiV # TODO: move to layout
     model_config = SettingsConfigDict(env_prefix="SCADA_", extra="ignore")
 

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -634,7 +634,7 @@ class Scada(ScadaInterface, Proactor):
             )
         self._send_to(self.atomic_ally, payload)
         self.generate_event(RemainingElecEvent(Remaining=payload))
-        self.log("Sent remaining elec to ATN and atomic ally")
+        #self.log("Sent remaining elec to ATN and atomic ally")
 
     def scada_params_received(
         self, from_node: ShNode, payload: ScadaParams, testing: bool = False

--- a/gw_spaceheat/actors/scada_actor.py
+++ b/gw_spaceheat/actors/scada_actor.py
@@ -250,13 +250,7 @@ class ScadaActor(Actor):
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=trigger_id,
             )
-            if from_node is None:
-                self._send_to(self.vdc_relay, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.vdc_relay.name,
-                            Payload=event))
+            self._send_to(self.vdc_relay, event, from_node)
             self.log(f"CloseRelay to {self.vdc_relay.name}")
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -278,13 +272,7 @@ class ScadaActor(Actor):
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=trigger_id,
             )
-            if from_node is None:
-                self._send_to(self.vdc_relay, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.vdc_relay.name,
-                            Payload=event))
+            self._send_to(self.vdc_relay, event, from_node)
             self.log(f"OpenRelay to {self.vdc_relay.name}")
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -294,22 +282,18 @@ class ScadaActor(Actor):
         Close tstat common relay (de-energizing relay 2).
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.tstat_common_relay.handle,
                 EventType=ChangeRelayState.enum_name(),
                 EventName=ChangeRelayState.CloseRelay,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.tstat_common_relay, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.tstat_common_relay.name,
-                            Payload=event))
+            self._send_to(self.tstat_common_relay, event, from_node)
             self.log(f"{from_node.handle} sending CloseRelay to {self.tstat_common_relay.handle}")
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -319,22 +303,18 @@ class ScadaActor(Actor):
         Open tstat common relay (energizing relay 2).
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.tstat_common_relay.handle,
                 EventType=ChangeRelayState.enum_name(),
                 EventName=ChangeRelayState.OpenRelay,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.tstat_common_relay, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.tstat_common_relay.name,
-                            Payload=event))
+            self._send_to(self.tstat_common_relay, event, from_node)
             self.log(f"{from_node.handle} sending OpenRelay to {self.tstat_common_relay.handle}")
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -344,24 +324,20 @@ class ScadaActor(Actor):
         Set valves to discharge store (de-energizing) store_charge_discharge_relay (3).
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.store_charge_discharge_relay.handle,
                 EventType=ChangeStoreFlowRelay.enum_name(),
                 EventName=ChangeStoreFlowRelay.DischargeStore,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.store_charge_discharge_relay, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.store_charge_discharge_relay.name,
-                            Payload=event))
+            self._send_to(self.store_charge_discharge_relay, event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending DischargeStore to Store ChargeDischarge {self.store_charge_discharge_relay.handle}"
+                f"{from_node.handle} sending DischargeStore to Store ChargeDischarge {self.store_charge_discharge_relay.handle}"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -371,24 +347,20 @@ class ScadaActor(Actor):
         Set valves to charge store (energizing) store_charge_discharge_relay (3).
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.store_charge_discharge_relay.handle,
                 EventType=ChangeStoreFlowRelay.enum_name(),
                 EventName=ChangeStoreFlowRelay.ChargeStore,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.store_charge_discharge_relay, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.store_charge_discharge_relay.name,
-                            Payload=event))
+            self._send_to(self.store_charge_discharge_relay, event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending ChargeStore to Store ChargeDischarge {self.store_charge_discharge_relay.handle}"
+                f"{from_node.handle} sending ChargeStore to Store ChargeDischarge {self.store_charge_discharge_relay.handle}"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -398,24 +370,20 @@ class ScadaActor(Actor):
         Set the hp control to Aquastat by de-energizing hp_failsafe_relay (5)
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.hp_failsafe_relay.handle,
                 EventType=ChangeHeatPumpControl.enum_name(),
                 EventName=ChangeHeatPumpControl.SwitchToTankAquastat,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.hp_failsafe_relay, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.hp_failsafe_relay.name,
-                            Payload=event))
+            self._send_to(self.hp_failsafe_relay, event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending SwitchToTankAquastat to Hp Failsafe {self.hp_failsafe_relay.handle}"
+                f"{from_node.handle} sending SwitchToTankAquastat to Hp Failsafe {self.hp_failsafe_relay.handle}"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -425,24 +393,20 @@ class ScadaActor(Actor):
         Set the hp control to Scada by energizing hp_failsafe_relay (5)
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.hp_failsafe_relay.handle,
                 EventType=ChangeHeatPumpControl.enum_name(),
                 EventName=ChangeHeatPumpControl.SwitchToScada,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.hp_failsafe_relay, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.hp_failsafe_relay.name,
-                            Payload=event))
+            self._send_to(self.hp_failsafe_relay, event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending SwitchToScada to Hp Failsafe {self.hp_failsafe_relay.handle}"
+                f"{from_node.handle} sending SwitchToScada to Hp Failsafe {self.hp_failsafe_relay.handle}"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -453,24 +417,20 @@ class ScadaActor(Actor):
         from_node defaults to self.node if no from_node sent.
         Will log an error and do nothing if from_node is not the boss of HpRelayBoss
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.hp_relay_boss.handle,
                 EventType= TurnHpOnOff.enum_name(),
                 EventName=TurnHpOnOff.TurnOn,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.hp_relay_boss, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.hp_relay_boss.name,
-                            Payload=event))
+            self._send_to(self.hp_relay_boss, event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending CloseRelay to HpRelayBoss {self.hp_relay_boss.handle}"
+                f"{from_node.handle} sending CloseRelay to HpRelayBoss {self.hp_relay_boss.handle}"
             )
         except ValidationError as e:
             self.log(f"Tried to tell HpRelayBoss to turn on HP but didn't have rights: {e}")
@@ -481,24 +441,20 @@ class ScadaActor(Actor):
         from_node defaults to self.node if no from_node sent.
         Will log an error and do nothing if from_node is not the boss of HpRelayBoss
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.hp_relay_boss.handle,
                 EventType=TurnHpOnOff.enum_name(),
                 EventName=TurnHpOnOff.TurnOff,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.hp_relay_boss, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.hp_relay_boss.name,
-                            Payload=event))
+            self._send_to(self.hp_relay_boss, event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending OpenRelay to HpRelayBoss {self.hp_relay_boss.handle}"
+                f"{from_node.handle} sending OpenRelay to HpRelayBoss {self.hp_relay_boss.handle}"
             )
         except ValidationError as e:
             self.log(f"Tried to tell HpRelayBoss to turn off HP but didn't have rights: {e}")
@@ -508,24 +464,20 @@ class ScadaActor(Actor):
         Switch Aquastat ctrl from Scada to boiler by de-energizing aquastat_control_relay (8).
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.aquastat_control_relay.handle,
                 EventType=ChangeAquastatControl.enum_name(),
                 EventName=ChangeAquastatControl.SwitchToBoiler,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.aquastat_control_relay, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.aquastat_control_relay.name,
-                            Payload=event))
+            self._send_to(self.aquastat_control_relay, event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending SwitchToBoiler to Boiler Ctrl {self.aquastat_control_relay.handle}"
+                f"{from_node.handle} sending SwitchToBoiler to Boiler Ctrl {self.aquastat_control_relay.handle}"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -535,24 +487,20 @@ class ScadaActor(Actor):
         Switch Aquastat ctrl from boiler to Scada by energizing aquastat_control_relay (8).
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.aquastat_control_relay.handle,
                 EventType=ChangeAquastatControl.enum_name(),
                 EventName=ChangeAquastatControl.SwitchToScada,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.aquastat_control_relay, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.aquastat_control_relay.name,
-                            Payload=event))
+            self._send_to(self.aquastat_control_relay, event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending SwitchToScada to Aquastat Ctrl {self.aquastat_control_relay.handle}"
+                f"{from_node.handle} sending SwitchToScada to Aquastat Ctrl {self.aquastat_control_relay.handle}"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -562,6 +510,8 @@ class ScadaActor(Actor):
         Turn off the store pump by opening (de-energizing) store_pump_failsafe relay (9).
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
                 FromHandle=self.node.handle if from_node is None else from_node.handle,
@@ -571,15 +521,9 @@ class ScadaActor(Actor):
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.store_pump_failsafe, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.store_pump_failsafe.name,
-                            Payload=event))
+            self._send_to(self.store_pump_failsafe, event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending OpenRelay to StorePump OnOff {self.store_pump_failsafe.handle}"
+                f"{from_node.handle} sending OpenRelay to StorePump OnOff {self.store_pump_failsafe.handle}"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -589,22 +533,18 @@ class ScadaActor(Actor):
         Turn on the store pump by closing (energizing) store_pump_failsafe relay (9).
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.store_pump_failsafe.handle,
                 EventType=ChangeRelayState.enum_name(),
                 EventName=ChangeRelayState.CloseRelay,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.store_pump_failsafe, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.store_pump_failsafe.name,
-                            Payload=event))
+            self._send_to(self.store_pump_failsafe, event, from_node)
             self.log(
                 f"{self.node.handle if from_node is None else from_node.handle} sending CloseRelay to StorePump OnOff {self.store_pump_failsafe.handle}"
             )
@@ -617,24 +557,20 @@ class ScadaActor(Actor):
         primary_pump_failsafe_relay (12).
         Will log an error and do nothing if not the boss of this relay
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.primary_pump_failsafe.handle,
                 EventType=ChangePrimaryPumpControl.enum_name(),
                 EventName=ChangePrimaryPumpControl.SwitchToHeatPump,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.primary_pump_failsafe, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.primary_pump_failsafe.name,
-                            Payload=event))
+            self._send_to(self.primary_pump_failsafe, event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending SwitchToHeatPump to {self.primary_pump_failsafe.handle}"
+                f"{from_node.handle} sending SwitchToHeatPump to {self.primary_pump_failsafe.handle}"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -645,22 +581,18 @@ class ScadaActor(Actor):
         primary_pump_failsafe_relay (12).
         Will log an error and do nothing if not the boss of this relay.
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.primary_pump_failsafe.handle,
                 EventType=ChangePrimaryPumpControl.enum_name(),
                 EventName=ChangePrimaryPumpControl.SwitchToScada,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.primary_pump_failsafe, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.primary_pump_failsafe.name,
-                            Payload=event))
+            self._send_to(self.primary_pump_failsafe, event, from_node)
             self.log(
                 f"{self.node.handle if from_node is None else from_node.handle} sending SwitchToHeatPump to {self.primary_pump_failsafe.handle}"
             )
@@ -673,22 +605,18 @@ class ScadaActor(Actor):
         primary_pump_scada_ops (11).
         Will log an error and do nothing if not the boss of this relay.
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.primary_pump_scada_ops.handle,
                 EventType=ChangeRelayState.enum_name(),
                 EventName=ChangeRelayState.OpenRelay,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.primary_pump_scada_ops, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.primary_pump_scada_ops.name,
-                            Payload=event))
+            self._send_to(self.primary_pump_scada_ops, event, from_node)
             self.log(
                 f"{self.node.handle if from_node is None else from_node.handle} sending OpenRelay to {self.primary_pump_scada_ops.handle}"
             )
@@ -701,22 +629,18 @@ class ScadaActor(Actor):
         primary_pump_scada_ops (11).
         Will log an error and do nothing if not the boss of this relay.
         """
+        if from_node is None:
+            from_node = self.node
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.primary_pump_scada_ops.handle,
                 EventType=ChangeRelayState.enum_name(),
                 EventName=ChangeRelayState.CloseRelay,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.primary_pump_scada_ops, event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.primary_pump_scada_ops.name,
-                            Payload=event))
+            self._send_to(self.primary_pump_scada_ops, event, from_node)
             self.log(
                 f"{self.node.handle if from_node is None else from_node.handle} sending CloseRelay to {self.primary_pump_scada_ops.handle}"
             )
@@ -729,6 +653,8 @@ class ScadaActor(Actor):
         by energizing appropriate relay.
         Will log an error and do nothing if not the boss of this relay.
         """
+        if from_node is None:
+            from_node = self.node
         if zone not in self.layout.zone_list:
             self.log(f"{zone} not a recongized zone!")
             return
@@ -741,15 +667,10 @@ class ScadaActor(Actor):
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.stat_failsafe_relay(zone), event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.stat_failsafe_relay(zone).name,
-                            Payload=event))
+
+            self._send_to(self.stat_failsafe_relay(zone), event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending SwitchToScada to {self.stat_failsafe_relay(zone).handle} (zone {zone})"
+                f"{from_node.handle} sending SwitchToScada to {self.stat_failsafe_relay(zone).handle} (zone {zone})"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -760,27 +681,23 @@ class ScadaActor(Actor):
         by de-energizing appropriate relay.
         Will log an error and do nothing if not the boss of this relay.
         """
+        if from_node is None:
+            from_node = self.node
         if zone not in self.layout.zone_list:
             self.log(f"{zone} not a recongized zone!")
             return
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.stat_failsafe_relay(zone).handle,
                 EventType=ChangeHeatcallSource.enum_name(),
                 EventName=ChangeHeatcallSource.SwitchToWallThermostat,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.stat_failsafe_relay(zone), event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.stat_failsafe_relay(zone).name,
-                            Payload=event))
+            self._send_to(self.stat_failsafe_relay(zone), event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending SwitchToWallThermostat to {self.stat_failsafe_relay(zone).handle} (zone {zone})"
+                f"{from_node.handle} sending SwitchToWallThermostat to {self.stat_failsafe_relay(zone).handle} (zone {zone})"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -791,27 +708,23 @@ class ScadaActor(Actor):
         wire IF the associated failsafe relay is energized (switched to SCADA).
         Will log an error and do nothing if not the boss of this relay.
         """
+        if from_node is None:
+            from_node = self.node
         if zone not in self.layout.zone_list:
             self.log(f"{zone} not a recongized zone!")
             return
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.stat_ops_relay(zone).handle,
                 EventType=ChangeRelayState.enum_name(),
                 EventName=ChangeRelayState.CloseRelay,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.stat_ops_relay(zone), event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.stat_ops_relay(zone).name,
-                            Payload=event))
+            self._send_to(self.stat_ops_relay(zone), event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending CloseRelay to {self.stat_ops_relay(zone).handle} (zone {zone})"
+                f"{from_node.handle} sending CloseRelay to {self.stat_ops_relay(zone).handle} (zone {zone})"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -822,27 +735,23 @@ class ScadaActor(Actor):
         wire IF the associated failsafe relay is energized (switched to SCADA).
         Will log an error and do nothing if not the boss of this relay.
         """
+        if from_node is None:
+            from_node = self.node
         if zone not in self.layout.zone_list:
             self.log(f"{zone} not a recongized zone!")
             return
         try:
             event = FsmEvent(
-                FromHandle=self.node.handle if from_node is None else from_node.handle,
+                FromHandle=from_node.handle,
                 ToHandle=self.stat_ops_relay(zone).handle,
                 EventType=ChangeRelayState.enum_name(),
                 EventName=ChangeRelayState.OpenRelay,
                 SendTimeUnixMs=int(time.time() * 1000),
                 TriggerId=str(uuid.uuid4()),
             )
-            if from_node is None:
-                self._send_to(self.stat_ops_relay(zone), event)
-            else:
-                self.services.send(
-                    Message(Src=from_node.name,
-                            Dst=self.stat_ops_relay(zone).name,
-                            Payload=event))
+            self._send_to(self.stat_ops_relay(zone), event, from_node)
             self.log(
-                f"{self.node.handle if from_node is None else from_node.handle} sending OpenRelay to {self.stat_ops_relay(zone).handle} (zone {zone})"
+                f"{from_node.handle} sending OpenRelay to {self.stat_ops_relay(zone).handle} (zone {zone})"
             )
         except ValidationError as e:
             self.log(f"Tried to change a relay but didn't have the rights: {e}")
@@ -858,7 +767,7 @@ class ScadaActor(Actor):
     def the_boss_of(self, node: ShNode) -> Optional[ShNode]:
         if node.Handle == node.Name:
             return None
-        boss_name= ".".join(node.Handle.split(".")[-2])
+        boss_name= node.Handle.split(".")[-2]
         return self.layout.node(boss_name, None)
 
     def direct_reports(self) -> list[ShNode]:

--- a/gw_spaceheat/actors/strat_boss.py
+++ b/gw_spaceheat/actors/strat_boss.py
@@ -52,7 +52,7 @@ class StratBoss(ScadaActor):
     circulating water is likely still above room temperature, just not enough to actively heat.
 
     """
-    TIMEOUT_MINUTES = 12
+    TIMEOUT_MINUTES = 20
     
     DIST_PUMP_ON_SECONDS = 45 # time it takes to get the distributin pump on when its off
     VALVED_TO_DISCHARGE_SECONDS = 30 # time it takes to go from valve in charge -> valve in discharge
@@ -261,7 +261,7 @@ class StratBoss(ScadaActor):
             wait_s = self.primary_pump_delay_seconds - max_strat_prep_seconds # could be ~75 s for LG
             if wait_s > 5:
                 wait_s = wait_s - 5
-                self.log(f"Waiting {wait_s} before changing relays")
+                self.log(f"Waiting {wait_s} s before changing relays")
                 await asyncio.sleep(wait_s)
         asyncio.create_task(self._lift_timer())
         #Make sure we're still active before proceeding in case we waited.
@@ -302,7 +302,6 @@ class StratBoss(ScadaActor):
     
     async def _timeout_timer(self) -> None:
         """ Wait 12 minutes. If still active at the end then pull the ActiveTwelveMinutes Trigger"""
-        self.log(f"Waiting {self.TIMEOUT_MINUTES} minutes and then timing out if still active")
         await asyncio.sleep(self.TIMEOUT_MINUTES * 60)
         if self.state == StratBossState.Active:
             self.log(f"Letting boss know its time to go dormant: Timeout event after {self.TIMEOUT_MINUTES}")
@@ -325,7 +324,6 @@ class StratBoss(ScadaActor):
         while not self._stop_requested:
             if time.time() - self.last_pat_s > self.WATCHDOG_PAT_S:
                 self._send(PatInternalWatchdogMessage(src=self.name))
-                self.log("Patting watchdog)")
                 self.last_pat_s = time.time()
             try: 
                 good_readings = self.update_power_readings()

--- a/gw_spaceheat/actors/synth_generator.py
+++ b/gw_spaceheat/actors/synth_generator.py
@@ -200,13 +200,13 @@ class SynthGenerator(ScadaActor):
         if self.elec_assigned_amount is None or self.previous_time is None:
             return
         time_now = time.time() * 1000
-        self.log(f"The HP power was {round(self.previous_watts,1)} Watts {round((time_now-self.previous_time)/1000,1)} seconds ago")
+        # self.log(f"The HP power was {round(self.previous_watts,1)} Watts {round((time_now-self.previous_time)/1000,1)} seconds ago")
         elec_watthours = self.previous_watts * (time_now - self.previous_time)/1000/3600
-        self.log(f"This corresponds to an additional {round(elec_watthours,1)} Wh of electricity used")
+        #self.log(f"This corresponds to an additional {round(elec_watthours,1)} Wh of electricity used")
         self.elec_used_since_assigned_time += elec_watthours
-        self.log(f"Electricity used since EnergyInstruction: {round(self.elec_used_since_assigned_time,1)} Wh")
+        #self.log(f"Electricity used since EnergyInstruction: {round(self.elec_used_since_assigned_time,1)} Wh")
         remaining_wh = int(self.elec_assigned_amount - self.elec_used_since_assigned_time)
-        self.log(f"Remaining electricity to be used from EnergyInstruction: {remaining_wh} Wh")
+        #self.log(f"Remaining electricity to be used from EnergyInstruction: {remaining_wh} Wh")
         remaining = RemainingElec(
             FromGNodeAlias=self.layout.atn_g_node_alias,
             RemainingWattHours=remaining_wh

--- a/tests/atn/atn_config.py
+++ b/tests/atn/atn_config.py
@@ -2,7 +2,7 @@ import re
 
 from pydantic import BaseModel
 from pydantic import model_validator
-
+from enums import HpModel
 from gwproactor import ProactorSettings
 from gwproactor.config import MQTTClient
 from pydantic_settings import SettingsConfigDict
@@ -44,7 +44,9 @@ class AtnSettings(ProactorSettings):
     latitude: float = 45.6573 
     longitude: float = -68.7098
     is_simulated: bool = False
-
+    fuel_substitution: bool = True
+    fuel_sub_usd_per_mwh: int = 250 # hack until we account for COP etc
+    hp_model: HpModel = HpModel.SamsungHighTempHydroKitPlusMultiV # TODO: move to layout
     model_config = SettingsConfigDict(env_prefix="ATN_", extra="ignore")
 
 

--- a/tests/test_misc/test_config.py
+++ b/tests/test_misc/test_config.py
@@ -46,7 +46,6 @@ def test_scada_settings_defaults(clean_scada_env):
         max_ewt_f=170,
         load_overestimation_percent=0,
         oil_boiler_for_onpeak_backup=True,
-        fuel_substitution=True,
         pico_cycler_state_logging=False,
         power_meter_logging_level=logging.WARNING,
         local_mqtt=exp_local_mqtt.model_dump(),


### PR DESCRIPTION
Bugs:
  - the_boss_of in scada_actor had boss_name=  ".".join(node.Handle.split(".")[-2]) instead of node.Handle.split(".")[-2]. Both were `h` for home alone but `aa` became `a.a`
  - scada_actor's  close_tsat_common_relay logged from_node.handle even when from_node was none. Cleaned up all those pipes with updated _send_to
  - Removed potential race condition where a message could trigger state change in AtomicAlly without changing relays by calling update_relays from inside trigger_event and making prev_state an attribute of AtomicALly

Extended timeout minutes for StratBoss to 20
Fuel Substitution for atn and price not tariff dependent
 - AtomicAlly respects HackOilOn if it isn't Dormant are already running the oil boiler
 - Atn sends HackOilOn on the basis of price comparison not a time-based tariff
 - Atn has new config variables fuel_substitution (defaults to True) and fuel_sub_price_per_mwh (defaults to 250). This is a hack that can be made better w accounting for variable COP, oil price and oil burner efficiency [LATER]
 - send_energy_dispatches (old energy_isntructions)
    - does not have game_on
	- waits asynchronously until top of next 5 minutes if more than 5 seconds after top of 5
 - Change get_price_forecast to ALWAYS return current price and to be called get_price_update_forecast_usd_per_wh
 - Add a send_latest_price method to help trigger sending energy instructions
    - use this followed by send_energy_dispatches(Watts, minutes). Note send_energy_dispatches won't do anything if there isn't a latest price.