### PR TITLE
StratBoss and RelayMultiplexer improvements

### DIFF
--- a/gw_spaceheat/actors/atomic_ally.py
+++ b/gw_spaceheat/actors/atomic_ally.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import datetime
 import uuid
 from enum import auto
 from typing import cast, List, Sequence, Optional
@@ -124,7 +125,6 @@ class AtomicAlly(ScadaActor):
         )     
         self.state: AtomicAllyState = AtomicAllyState.Dormant
         self.prev_state: AtomicAllyState = AtomicAllyState.Dormant 
-        self.timezone = pytz.timezone(self.settings.timezone_str)
         self.is_simulated = self.settings.is_simulated
         self.log(f"Params: {self.params}")
         self.log(f"self.is_simulated: {self.is_simulated}")

--- a/gw_spaceheat/actors/config.py
+++ b/gw_spaceheat/actors/config.py
@@ -25,6 +25,7 @@ class ScadaSettings(ProactorSettings):
     pico_cycler_state_logging: bool = False
     power_meter_logging_level: int = logging.WARNING
     contract_rep_logging_level: int = logging.INFO
+    relay_multiplexer_logging_level: int = logging.INFO
     local_mqtt: MQTTClient = MQTTClient()
     gridworks_mqtt: MQTTClient = MQTTClient()
     seconds_per_report: int = 300

--- a/gw_spaceheat/actors/home_alone.py
+++ b/gw_spaceheat/actors/home_alone.py
@@ -180,7 +180,6 @@ class HomeAlone(ScadaActor):
             self.top_state = HomeAloneTopState.Monitor
         else: 
             self.top_state = HomeAloneTopState.Normal
-        self.timezone = pytz.timezone(self.settings.timezone_str)
         self.is_simulated = self.settings.is_simulated
         self.oil_boiler_during_onpeak = self.settings.oil_boiler_for_onpeak_backup
         self.log(f"Params: {self.params}")

--- a/gw_spaceheat/actors/relay.py
+++ b/gw_spaceheat/actors/relay.py
@@ -33,13 +33,13 @@ from gwproto.enums import (
 
 )
 
-from gwproto.named_types import FsmAtomicReport, FsmFullReport, MachineStates
+from gwproto.named_types import FsmAtomicReport, FsmFullReport
 from result import Err, Ok, Result
 from transitions import Machine
 from data_classes.house_0_names import House0RelayIdx
 from actors.scada_actor import ScadaActor
 from enums import LogLevel, ChangeKeepSend, HpLoopKeepSend
-from named_types import FsmEvent, Glitch
+from named_types import FsmEvent, Glitch, SingleMachineState
 
 class Relay(ScadaActor):
     STATE_REPORT_S = 300
@@ -258,11 +258,11 @@ class Relay(ScadaActor):
         # self.log(f"[{self.my_channel().Name}] {self.state}")
         self._send_to(
             self.primary_scada,
-            MachineStates(
+            SingleMachineState(
                 MachineHandle=self.node.handle,
                 StateEnum=self.my_state_enum.enum_name(),
-                StateList=[self.state],
-                UnixMsList=[now_ms],
+                State=self.state,
+                UnixMs=now_ms,
             ),
         )
 

--- a/gw_spaceheat/actors/scada_actor.py
+++ b/gw_spaceheat/actors/scada_actor.py
@@ -1,13 +1,13 @@
 import time
 import uuid
 from typing import Any, Dict, List, Optional, cast
-
-from actors.config import ScadaSettings
+import pytz
 from actors.scada_data import ScadaData
 from data_classes.house_0_layout import House0Layout
 from data_classes.house_0_names import H0N, House0RelayIdx
 from gw.errors import DcError
-from gwproactor import Actor, ServicesInterface, QOS
+from actors.scada_interface import ScadaInterface
+from gwproactor import Actor,  QOS
 from gwproto import Message
 from gwproto.data_classes.sh_node import ShNode
 from gwproto.enums import (
@@ -26,11 +26,11 @@ from pydantic import ValidationError
 
 
 class ScadaActor(Actor):
-    layout: House0Layout
-    node: ShNode
 
-    def __init__(self, name: str, services: ServicesInterface):
+    def __init__(self, name: str, services: ScadaInterface):
         super().__init__(name, services)
+        self.settings = services.settings
+        self.timezone = pytz.timezone(self.settings.timezone_str)
 
     @property
     def node(self) -> ShNode:
@@ -44,10 +44,6 @@ class ScadaActor(Actor):
         except Exception as e:
             raise Exception(f"Failed to cast layout as House0Layout!! {e}")
         return layout
-
-    @property
-    def settings(self) -> ScadaSettings:
-        return self.services.settings
 
     @property
     def data(self) -> ScadaData:

--- a/gw_spaceheat/actors/subscription_handler.py
+++ b/gw_spaceheat/actors/subscription_handler.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+from gwproto.property_format import SpaceheatName
+
+class StateMachineSubscription(BaseModel):
+    subscriber_name: SpaceheatName
+    publisher_name: SpaceheatName
+
+class ChannelSubscription(BaseModel):
+    subscriber_name: SpaceheatName
+    channel_name: SpaceheatName

--- a/gw_spaceheat/data_classes/house_0_names.py
+++ b/gw_spaceheat/data_classes/house_0_names.py
@@ -11,6 +11,7 @@ class ZoneNodes:
         zone_name = f"zone{idx + 1}-{zone}".lower()
         self.zone_name = zone_name
         self.stat = f"{zone_name}-stat"
+        self.whitewire=f"zone{idx + 1}-{zone}-whitewire"
 
     def __repr__(self) -> str:
         return f"Zone {self.zone_name} and stat {self.stat}"
@@ -35,9 +36,10 @@ class ZoneChannelNames:
         self.temp = f"{self.zone_name}-temp"
         self.set = f"{self.zone_name}-set"
         self.state = f"{self.zone_name}-state"
+        self.whitewire_pwr=f"zone{idx}-{zone}-whitewire-pwr"
 
     def __repr__(self) -> str:
-        return f"Channels: .temp: {self.temp}, .set: {self.set}, .state: {self.state}"
+        return f"Channels: {self.temp}, {self.set}, {self.state}, {self.whitewire_pwr}"
 
 
 class TankChannelNames:
@@ -83,6 +85,7 @@ class H0N:
     zero_ten_out_multiplexer = "dfr-multiplexer"
     hp_relay_boss = "hp-relay-boss"
     strat_boss = "strat-boss"
+    pump_doctor = "pump-doc"
 
     # core power-metered nodes
     hp_odu = "hp-odu"
@@ -359,25 +362,26 @@ class H0CN:
                 TelemetryName=TelemetryName.WaterTempCTimes1000,
             )
         for i in self.zone:
-            d[self.zone[i].temp] = (
-                ChannelStub(
+            d[self.zone[i].temp] = ChannelStub(
                     Name=self.zone[i].temp,
                     AboutNodeName=self.zone[i].zone_name,
                     TelemetryName=TelemetryName.AirTempFTimes1000,
                 ),
-            )
-            d[self.zone[i].set] = (
-                ChannelStub(
+    
+            d[self.zone[i].set] = ChannelStub(
                     Name=self.zone[i].temp,
                     AboutNodeName=self.zone[i].stat_name,
                     TelemetryName=TelemetryName.AirTempFTimes1000,
                 ),
-            )
-            d[self.zone[i].set] = (
-                ChannelStub(
+            d[self.zone[i].set] = ChannelStub(
                     Name=self.zone[i].state,
                     AboutNodeName=self.zone[i].stat_name,
                     TelemetryName=TelemetryName.ThermostatState,
                 ),
-            )
+            d[self.zone[i].whitewire] = ChannelStub(
+                    Name=self.zone[i].state,
+                    AboutNodeName=self.zone[i].stat_name,
+                    TelemetryName=TelemetryName.ThermostatState,
+                ),
+            
         return d

--- a/tests/test_misc/test_config.py
+++ b/tests/test_misc/test_config.py
@@ -50,6 +50,7 @@ def test_scada_settings_defaults(clean_scada_env):
         stratboss_dist_010v=100,
         pico_cycler_state_logging=False,
         power_meter_logging_level=logging.WARNING,
+        relay_multiplexer_logging_level=logging.INFO,
         local_mqtt=exp_local_mqtt.model_dump(),
         gridworks_mqtt=MQTTClient(
             tls=TLSInfo().update_tls_paths(


### PR DESCRIPTION
 - tracks state of the HpScadaOpsRelay and uses that to determine whether or not to trigger - this fixed a lurking bug
 - Add stat_boss_exemption_zones, stat_boss_exemption_hours and exempted_strat_boss_dist_010v
    - for example if ['living-rm', 'bedroom'] is the zone list and you only want the bedroom to be in the StratBoss zones between the hours of 5 am and 4 pm, in hardware layout: 
     "ExemptedStratBossDist010V": 88, 
     "StratBossExemptionZones": ["bedroom"], 
     "StratBossExemptionHours": [0, 1, 2, 3, 4, 16, 17, 18, 19, 20, 21, 22, 23] 
     Note that with fewer zones the 010 setting must be higher. Right now SCADA_STRATBOSS_DIST_010V is still in .env. When George can generate hardware layouts I'll move that to hardware layout.
	- as another example, include all zones and all hours to shut down the strat boss entirely 
-Add whitewire names to hardware layout. Template: zone1-bedroom-whitewire for node, zone1-bedroom-whitewire-pwr for channel
- Create concept of Subscriptions - nodes subscribing to channels and/or StateMachine updates

I2C Multiplexer improvements
  - tries up to 3 times, with backoff, to initialize each relay board
  - logs what it is doing.
  - Added a RelayMultiplexerLogger with logging level set in .env, following the pattern established by Andy w Power Meter
  - Sends Glitch with LogLevel Critical if forced to simulate a board
  - Sends Glitch with LogLevel Info if had to try more than once with a board
  - Only start the maintain_relay_states AFTER the board has been initialized
  - Check that a relay has been initialized before changing its state